### PR TITLE
Add non-default jcenter repository to allow graphql-dgs-codegen-core …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,4 +162,11 @@
         </license>
     </licenses>
 
+    <repositories>
+        <repository>
+            <id>jcenter</id>
+            <name>jcenter</name>
+            <url>https://jcenter.bintray.com</url>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
…to be resolved if it isn't set in overall maven settings