### PR TITLE
Upgraded dgscodegen to 5.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,39 @@ Example
 <language>kotlin</language>
 ```
 
+## omitNullInputFields
+
+- Type: boolean
+- Required: false
+- Default: false
+
+Example
+```xml
+<omitNullInputFields>false</omitNullInputFields>
+```
+
+## kotlinAllFieldsOptional
+
+- Type: boolean
+- Required: false
+- Default: false
+
+Example
+```xml
+<kotlinAllFieldsOptional>false</kotlinAllFieldsOptional>
+```
+
+## snakeCaseConstantNames
+
+- Type: boolean
+- Required: false
+- Default: false
+
+Example
+```xml
+<snakeCaseConstantNames>false</snakeCaseConstantNames>
+```
+
 # Usage
 
 Add the following to your pom files build/plugins section.

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>com.netflix.graphql.dgs.codegen</groupId>
             <artifactId>graphql-dgs-codegen-core</artifactId>
-            <version>4.4.1</version>
+            <version>5.0.3</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
@@ -73,6 +73,15 @@ public class Codegen extends AbstractMojo {
     @Parameter(property = "language", defaultValue = "java")
     private String language;
 
+    @Parameter(property = "omitNullInputFields", defaultValue = "false")
+    private boolean omitNullInputFields;
+
+    @Parameter(property = "kotlinAllFieldsOptional", defaultValue = "false")
+    private boolean kotlinAllFieldsOptional;
+
+    @Parameter(property = "snakeCaseConstantNames", defaultValue = "false")
+    private boolean snakeCaseConstantNames;
+
 
     private void verifySettings() {
         if (packageName == null) {
@@ -117,7 +126,10 @@ public class Codegen extends AbstractMojo {
                 skipEntityQueries,
                 shortProjectionNames,
                 generateDataTypes,
-                maxProjectionDepth
+                omitNullInputFields,
+                maxProjectionDepth,
+                kotlinAllFieldsOptional,
+                snakeCaseConstantNames
         );
 
         getLog().info("Codegen config: " + config);


### PR DESCRIPTION
I noticed that the latest version of dgs serializes queries incorrectly with the latest version of the maven codegen plugin. Namely, it doesn't use the graphql type name when generating the query fragment and instead uses the classname. This is because no `schemaType` is provided in older versions of the generated code.

Updating to the latest version of the code gen library fixes this when using the gradle plugin, so this is what I've tried to do here for the maven plugin.

This is my first time making a change to a maven plugin, so I hope it works. I'm not sure the best way of testing it. The best that can be said of this is that it compiles :)