### PR TITLE
Bump graphql-dgs-codegen-core => 5.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,17 @@ Example
 <generateCustomAnnotations>false</generateCustomAnnotations>
 ```
 
+## addDeprecatedAnnotation
+
+- Type: boolean
+- Required: false
+- Default: false
+
+```xml
+
+<addDeprecatedAnnotation>false</addDeprecatedAnnotation>
+```
+
 ## includeImports
 
 - Type: map<string, string>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 	</scm>
 
 	<properties>
-		<graphql-dgs-codegen-core.version>5.2.7</graphql-dgs-codegen-core.version>
+		<graphql-dgs-codegen-core.version>5.3.0</graphql-dgs-codegen-core.version>
 		<java.version>1.8</java.version>
 		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
 		<maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>io.github.deweyjose</groupId>
 	<artifactId>graphqlcodegen-maven-plugin</artifactId>
 	<packaging>maven-plugin</packaging>
-	<version>1.24</version>
+	<version>1.25</version>
 
 	<name>GraphQL Code Generator</name>
 	<description>Maven port of the Netflix DGS GraphQL Codegen gradle build plugin</description>
@@ -33,7 +33,7 @@
 	</scm>
 
 	<properties>
-		<graphql-dgs-codegen-core.version>5.4.0</graphql-dgs-codegen-core.version>
+		<graphql-dgs-codegen-core.version>5.5.0</graphql-dgs-codegen-core.version>
 		<java.version>1.8</java.version>
 		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
 		<maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,6 @@
 
 	<properties>
 		<graphql-dgs-codegen-core.version>5.2.7</graphql-dgs-codegen-core.version>
-		<graphql-dgs-codegen-core.version>5.2.7</graphql-dgs-codegen-core.version>
 		<java.version>1.8</java.version>
 		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
 		<maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,8 @@
 	</scm>
 
 	<properties>
-		<graphql-dgs-codegen-core.version>5.2.6</graphql-dgs-codegen-core.version>
+		<graphql-dgs-codegen-core.version>5.2.7</graphql-dgs-codegen-core.version>
+		<graphql-dgs-codegen-core.version>5.2.7</graphql-dgs-codegen-core.version>
 		<java.version>1.8</java.version>
 		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
 		<maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>io.github.deweyjose</groupId>
 	<artifactId>graphqlcodegen-maven-plugin</artifactId>
 	<packaging>maven-plugin</packaging>
-	<version>1.21</version>
+	<version>1.22</version>
 
 	<name>GraphQL Code Generator</name>
 	<description>Maven port of the Netflix DGS GraphQL Codegen gradle build plugin</description>
@@ -33,7 +33,7 @@
 	</scm>
 
 	<properties>
-		<graphql-dgs-codegen-core.version>5.2.5</graphql-dgs-codegen-core.version>
+		<graphql-dgs-codegen-core.version>5.2.6</graphql-dgs-codegen-core.version>
 		<java.version>1.8</java.version>
 		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
 		<maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>io.github.deweyjose</groupId>
 	<artifactId>graphqlcodegen-maven-plugin</artifactId>
 	<packaging>maven-plugin</packaging>
-	<version>1.22</version>
+	<version>1.23</version>
 
 	<name>GraphQL Code Generator</name>
 	<description>Maven port of the Netflix DGS GraphQL Codegen gradle build plugin</description>

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
@@ -114,6 +114,15 @@ public class Codegen extends AbstractMojo {
 	@Parameter(property = "dgs.codegen.skip", defaultValue = "false", required = false)
 	private boolean skip;
 
+	@Parameter(property = "generateCustomAnnotations", defaultValue = "false")
+	private boolean generateCustomAnnotations;
+
+	@Parameter(property = "includeImports")
+	private Map<String, String> includeImports;
+
+	@Parameter(property = "includeEnumImports")
+	private Map<String, Map<String, String>> includeEnumImports;
+
 	private void verifySettings() {
 		if (isNull(packageName)) {
 			throw new RuntimeException("Please specify a packageName");
@@ -168,6 +177,9 @@ public class Codegen extends AbstractMojo {
 					kotlinAllFieldsOptional,
 					snakeCaseConstantNames,
 					generateInterfaceSetters,
+					includeImports,
+					includeEnumImports,
+					generateCustomAnnotations,
 				    javaGenerateAllConstructor,
 				    implementSerializable,
 				    addGeneratedAnnotation

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
@@ -130,11 +130,7 @@ public class Codegen extends AbstractMojo {
 	private Map<String, String> includeImports;
 
 	@Parameter(property = "includeEnumImports")
-<<<<<<< HEAD
-	private Map<String, Map<String, String>> includeEnumImports;
-=======
 	private Map<String, Properties> includeEnumImports;
->>>>>>> upstream/main
 
 	private void verifySettings() {
 		if (isNull(packageName)) {


### PR DESCRIPTION
Updated to latest Dgs codegen release version of [5.5.0](https://github.com/Netflix/dgs-codegen/releases/tag/v5.5.0) 
Updated Readme to include addDeprecatedAnnotation