### PR TITLE
fix: clean up schema path validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>io.github.deweyjose</groupId>
 	<artifactId>graphqlcodegen-maven-plugin</artifactId>
 	<packaging>maven-plugin</packaging>
-	<version>1.40</version>
+	<version>1.41</version>
 
 	<name>GraphQL Code Generator</name>
 	<description>Maven port of the Netflix DGS GraphQL Codegen gradle build plugin</description>
@@ -45,6 +45,7 @@
 		<maven-release-plugin.version>3.0.0-M4</maven-release-plugin.version>
 		<maven-scm-provider-gitexe.version>1.11.2</maven-scm-provider-gitexe.version>
 		<nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+    <junit.version>5.9.2</junit.version>
 	</properties>
 
 	<dependencies>
@@ -69,6 +70,18 @@
 			<artifactId>graphql-dgs-codegen-core</artifactId>
 			<version>${graphql-dgs-codegen-core.version}</version>
 		</dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
 	</dependencies>
 
 	<distributionManagement>

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
@@ -161,7 +160,7 @@ public class Codegen extends AbstractMojo {
 			throw new RuntimeException("Please specify a packageName");
 		}
 
-		FileReducer.verifySchemaPaths(Arrays.stream(schemaPaths).collect(toList()));
+		Validations.verifySchemaPaths(Arrays.stream(schemaPaths).collect(toList()));
 
 		for (final String jarDep : schemaJarFilesFromDependencies) {
 			final String jarDepClean = jarDep.trim();

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
@@ -4,18 +4,14 @@ import static java.lang.String.format;
 import static java.util.Arrays.stream;
 import static java.util.Collections.emptySet;
 import static java.util.Objects.isNull;
-import static java.util.stream.Collectors.toMap;
-import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Collectors.*;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
@@ -165,13 +161,7 @@ public class Codegen extends AbstractMojo {
 			throw new RuntimeException("Please specify a packageName");
 		}
 
-		final int size = stream(schemaPaths).collect(toSet()).size();
-		if (schemaPaths.length != size) {
-			stream(schemaPaths).forEach(s -> {
-				getLog().error("schemaPath: " + s.getPath());
-			});
-			throw new RuntimeException("Duplicate entries in schemaPaths");
-		}
+		FileReducer.verifySchemaPaths(Arrays.stream(schemaPaths).collect(toList()));
 
 		for (final String jarDep : schemaJarFilesFromDependencies) {
 			final String jarDepClean = jarDep.trim();

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/FileReducer.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/FileReducer.java
@@ -1,0 +1,76 @@
+package io.github.deweyjose.graphqlcodegen;
+
+import java.io.File;
+import java.util.*;
+
+public class FileReducer {
+
+  /**
+   * We sort the input files by their paths to ensure a consistent order for processing.
+   *
+   * We maintain three sets:
+   *   validatedFiles to store the files that pass all checks,
+   *   encounteredDirectories to keep track of encountered directories
+   *   encounteredPaths to keep track of encountered paths.
+   *
+   * We iterate through the sorted files and perform the following checks:
+   *   Directory overlap: Skip files that are in directories already encountered.
+   *   Duplicate files: Skip files that are duplicates.
+   *   Ancestry in already added directories: Skip files that have ancestry in directories already encountered.
+   *
+   * Files that pass all checks are added to the validatedFiles set, and the corresponding
+   * directories and paths are updated in the encountered sets.
+   * @param files
+   */
+  public static Set<File> verifySchemaPaths(Collection<File> files) {
+    // Sort the input files to ensure consistent order
+    List<File> sortedFiles = new ArrayList<>(files);
+    sortedFiles.sort(Comparator.comparing(File::getPath));
+
+    Set<File> validatedFiles = new HashSet<>();
+    Set<File> encounteredDirectories = new HashSet<>();
+    Set<String> encounteredPaths = new HashSet<>();
+
+    for (File file : sortedFiles) {
+      String path = file.getPath();
+
+      // Check for directory overlap
+      File parent = file.getParentFile();
+      if (parent != null && encounteredDirectories.contains(parent)) {
+        throw new IllegalArgumentException(
+          String.format("Overlap detected: %s contains %s", parent.getPath(), file.getPath())
+        );
+      }
+
+      // Check for duplicate files
+      if (encounteredPaths.contains(path)) {
+        continue; // Skip this file, it's a duplicate
+      }
+
+      // Check for ancestry in already added directories
+      while (parent != null) {
+        if (encounteredDirectories.contains(parent)) {
+          throw new IllegalArgumentException(
+            String.format("Overlap detected: %s contains %s", parent.getPath(), file.getPath())
+          );
+        }
+        parent = parent.getParentFile();
+
+        if (parent != null && parent.equals(file)) {
+          break; // Avoid an infinite loop by checking if the parent is the same as the file
+        }
+      }
+
+      // This file passed all checks, add it to the validated files
+      validatedFiles.add(file);
+
+      // Update the encountered sets
+      if (file.isDirectory()) {
+        encounteredDirectories.add(file);
+      }
+      encounteredPaths.add(path);
+    }
+
+    return validatedFiles;
+  }
+}

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/Validations.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/Validations.java
@@ -3,7 +3,7 @@ package io.github.deweyjose.graphqlcodegen;
 import java.io.File;
 import java.util.*;
 
-public class FileReducer {
+public class Validations {
 
   /**
    * We sort the input files by their paths to ensure a consistent order for processing.
@@ -22,12 +22,11 @@ public class FileReducer {
    * directories and paths are updated in the encountered sets.
    * @param files
    */
-  public static Set<File> verifySchemaPaths(Collection<File> files) {
+  public static void verifySchemaPaths(Collection<File> files) {
     // Sort the input files to ensure consistent order
     List<File> sortedFiles = new ArrayList<>(files);
     sortedFiles.sort(Comparator.comparing(File::getPath));
 
-    Set<File> validatedFiles = new HashSet<>();
     Set<File> encounteredDirectories = new HashSet<>();
     Set<String> encounteredPaths = new HashSet<>();
 
@@ -61,16 +60,11 @@ public class FileReducer {
         }
       }
 
-      // This file passed all checks, add it to the validated files
-      validatedFiles.add(file);
-
       // Update the encountered sets
       if (file.isDirectory()) {
         encounteredDirectories.add(file);
       }
       encounteredPaths.add(path);
     }
-
-    return validatedFiles;
   }
 }

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/Validations.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/Validations.java
@@ -49,12 +49,6 @@ public class Validations {
         encounteredDirectories.add(file);
       }
 
-      // keep it simple, never allow duplicate configuration
-      if (encounteredPaths.contains(path)) {
-        throw new IllegalArgumentException(
-          String.format("Duplicate path configured: %s", path)
-        );
-      }
       encounteredPaths.add(path);
     }
   }

--- a/src/test/java/io/github/deweyjose/graphqlcodegen/FileReducerTest.java
+++ b/src/test/java/io/github/deweyjose/graphqlcodegen/FileReducerTest.java
@@ -1,8 +1,6 @@
 package io.github.deweyjose.graphqlcodegen;
 
-import junit.framework.Assert;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -17,7 +15,7 @@ class FileReducerTest {
   @ParameterizedTest
   @MethodSource("happyPathFileListProvider")
   void testHappyPaths(List<File> paths) {
-    Assertions.assertTrue(FileReducer.verifySchemaPaths(paths).containsAll(paths));
+    Assertions.assertDoesNotThrow(() -> Validations.verifySchemaPaths(paths));
   }
 
   @ParameterizedTest
@@ -25,7 +23,7 @@ class FileReducerTest {
   void testDirectoryOverlap(List<File> paths) {
     Assertions.assertThrows(
       IllegalArgumentException.class,
-      () -> FileReducer.verifySchemaPaths(paths),
+      () -> Validations.verifySchemaPaths(paths),
       "should not succeed"
     );
   }

--- a/src/test/java/io/github/deweyjose/graphqlcodegen/FileReducerTest.java
+++ b/src/test/java/io/github/deweyjose/graphqlcodegen/FileReducerTest.java
@@ -1,0 +1,88 @@
+package io.github.deweyjose.graphqlcodegen;
+
+import junit.framework.Assert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+class FileReducerTest {
+
+  @ParameterizedTest
+  @MethodSource("happyPathFileListProvider")
+  void testHappyPaths(List<File> paths) {
+    Assertions.assertTrue(FileReducer.verifySchemaPaths(paths).containsAll(paths));
+  }
+
+  @ParameterizedTest
+  @MethodSource("overlappingFileListProvider")
+  void testDirectoryOverlap(List<File> paths) {
+    Assertions.assertThrows(
+      IllegalArgumentException.class,
+      () -> FileReducer.verifySchemaPaths(paths),
+      "should not succeed"
+    );
+  }
+
+  /**
+   * wrapper for resource File objects
+   * @param path
+   * @return File
+   */
+  private static File getFile(String path) {
+    return new File(FileReducerTest.class.getClassLoader().getResource(path).getFile());
+  }
+
+  /**
+   * A set of scenarios with no overlapping ancestry.
+   * @return
+   */
+  private static Stream<Arguments> happyPathFileListProvider() {
+    return Stream.of(
+      Arguments.of(Arrays.asList(
+        getFile("schema")
+      )),
+      Arguments.of(Arrays.asList(
+        getFile("schema/bar"),
+        getFile("schema/foo")
+      )),
+      Arguments.of(Arrays.asList(
+        getFile("schema/bar/sink/kitchen.graphqls"),
+        getFile("schema/foo")
+      )),
+      Arguments.of(Arrays.asList(
+        getFile("schema/bar/sink/kitchen.graphqls"),
+        getFile("schema/foo/it.graphqls")
+      ))
+    );
+  }
+
+  /**
+   * A set of overlapping file scenarios.
+   * Each should fail in accordance with DGS
+   * inclusion behavior for parent directories.
+   * @return
+   */
+  private static Stream<Arguments> overlappingFileListProvider() {
+    return Stream.of(
+      Arguments.of(Arrays.asList(
+        getFile("schema"),
+        getFile("schema/bar")
+      )),
+      Arguments.of(Arrays.asList(
+        getFile("schema"),
+        getFile("schema/bar/sink/kitchen.graphqls")
+      )),
+      Arguments.of(Arrays.asList(
+        getFile("schema/bar/sink/kitchen.graphqls"),
+        getFile("schema/bar")
+      ))
+    );
+  }
+}

--- a/src/test/java/io/github/deweyjose/graphqlcodegen/ValidationsTest.java
+++ b/src/test/java/io/github/deweyjose/graphqlcodegen/ValidationsTest.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
-class FileReducerTest {
+class ValidationsTest {
 
   @ParameterizedTest
   @MethodSource("happyPathFileListProvider")
@@ -34,7 +34,7 @@ class FileReducerTest {
    * @return File
    */
   private static File getFile(String path) {
-    return new File(FileReducerTest.class.getClassLoader().getResource(path).getFile());
+    return new File(ValidationsTest.class.getClassLoader().getResource(path).getFile());
   }
 
   /**
@@ -75,11 +75,19 @@ class FileReducerTest {
       )),
       Arguments.of(Arrays.asList(
         getFile("schema"),
+        getFile("schema")
+      )),
+      Arguments.of(Arrays.asList(
+        getFile("schema"),
         getFile("schema/bar/sink/kitchen.graphqls")
       )),
       Arguments.of(Arrays.asList(
         getFile("schema/bar/sink/kitchen.graphqls"),
         getFile("schema/bar")
+      )),
+      Arguments.of(Arrays.asList(
+        getFile("schema/bar/sink/kitchen.graphqls"),
+        getFile("schema/bar/sink/kitchen.graphqls")
       ))
     );
   }

--- a/src/test/java/io/github/deweyjose/graphqlcodegen/ValidationsTest.java
+++ b/src/test/java/io/github/deweyjose/graphqlcodegen/ValidationsTest.java
@@ -57,6 +57,14 @@ class ValidationsTest {
       Arguments.of(Arrays.asList(
         getFile("schema/bar/sink/kitchen.graphqls"),
         getFile("schema/foo/it.graphqls")
+      )),
+      Arguments.of(Arrays.asList(
+        getFile("schema"),
+        getFile("schema")
+      )),
+      Arguments.of(Arrays.asList(
+        getFile("schema/bar/sink/kitchen.graphqls"),
+        getFile("schema/bar/sink/kitchen.graphqls")
       ))
     );
   }
@@ -75,19 +83,11 @@ class ValidationsTest {
       )),
       Arguments.of(Arrays.asList(
         getFile("schema"),
-        getFile("schema")
-      )),
-      Arguments.of(Arrays.asList(
-        getFile("schema"),
         getFile("schema/bar/sink/kitchen.graphqls")
       )),
       Arguments.of(Arrays.asList(
         getFile("schema/bar/sink/kitchen.graphqls"),
         getFile("schema/bar")
-      )),
-      Arguments.of(Arrays.asList(
-        getFile("schema/bar/sink/kitchen.graphqls"),
-        getFile("schema/bar/sink/kitchen.graphqls")
       ))
     );
   }


### PR DESCRIPTION
Clean up schema path validation. The previous checks only considered what was configured. However, DGS will traverse a directory and sub-directories when configured with a directory path as well as any explicit files. If the directory and files overlap this can lead to confusing compiler error messages about duplicate symbols.

This change will ensure no directory ancestral overlap with configured directory or file paths.

fixes #91 