### PR TITLE
no change no compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ This maven plugin is a port of the netflix codegen plugin for Gradle. Found [her
 Feel free to simply create a GitHub issue for requests to integrate with newer [releases](https://github.com/Netflix/dgs-codegen/releases) of the core DGS Codegen library.
 
 ### PRs
-PRS are welcome as well. The level of difficulty across DGS Codgen updates varies. Sometimes releases change the [CodeGenConfig](https://github.com/Netflix/dgs-codegen/blob/master/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt#L443) constructor - when new 
-options are added for example. 
+PRS are welcome as well. The level of difficulty across DGS Codgen updates varies. Sometimes releases change the [CodeGenConfig](https://github.com/Netflix/dgs-codegen/blob/master/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt#L443) constructor - when new
+options are added for example.
 
 Please make sure you run step 2 below to ensure your PR builds correctly. You may need to analyze the CodeGenConfig ctor parameters and add support for new options.
-Make sure to document any new options to the `Options` section below.  
+Make sure to document any new options to the `Options` section below.
 
 Process:
 1. bump the version in [pom.xml](pom.xml)
@@ -35,6 +35,21 @@ https://github.com/deweyjose/graphqlcodegen-example
 # Options
 
 Options are configured in the `<configuration>` element of the dgs-codegen-maven-plugin plugin.
+
+## onlyGenerateChanged
+
+This options enables the plugin to limit code generation to only schema files that have changed.
+Today this only works with schemaPaths.
+
+This only works for `<schemaPaths>`.  A subsequent release for schema compilation via dependencies will be release soon.
+
+- Type: boolean
+- Required: false
+- Default: true
+
+```xml
+<onlyGenerateChanged>true</onlyGenerateChanged>
+```
 
 ## subPackageNameDocs
 
@@ -99,7 +114,7 @@ Example
 Or
 
 ```shell
-# mvn ... -Ddgs.codegen.skip=true 
+# mvn ... -Ddgs.codegen.skip=true
 ```
 
 ## schemaPaths
@@ -121,8 +136,8 @@ Example
 
 - Type: array
 - Required: false
-- Default: 
-- Official doc : https://netflix.github.io/dgs/generating-code-from-schema/#generating-code-from-external-schemas-in-jars 
+- Default:
+- Official doc : https://netflix.github.io/dgs/generating-code-from-schema/#generating-code-from-external-schemas-in-jars
 
 Example
 
@@ -287,7 +302,7 @@ Example:
 
 ```xml
 <outputDir>${project.build.directory}/generated-examples</outputDir>
-```     
+```
 
 ## includeQueries
 
@@ -560,7 +575,7 @@ Maps the custom annotation and class names to the class packages. Only used when
     <bar>
         <properties>
             <zoo>bar.bar</zoo>
-      
+
             <zing>bla.bla</zing>
         </properties>
     </bar>

--- a/pom.xml
+++ b/pom.xml
@@ -1,75 +1,88 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
-	<groupId>io.github.deweyjose</groupId>
-	<artifactId>graphqlcodegen-maven-plugin</artifactId>
-	<packaging>maven-plugin</packaging>
-	<version>1.41</version>
+  <groupId>io.github.deweyjose</groupId>
+  <artifactId>graphqlcodegen-maven-plugin</artifactId>
+  <packaging>maven-plugin</packaging>
+  <version>1.50</version>
 
-	<name>GraphQL Code Generator</name>
-	<description>Maven port of the Netflix DGS GraphQL Codegen gradle build plugin</description>
-	<url>https://github.com/deweyjose/graphqlcodegen</url>
+  <name>GraphQL Code Generator</name>
+  <description>Maven port of the Netflix DGS GraphQL Codegen gradle build plugin</description>
+  <url>https://github.com/deweyjose/graphqlcodegen</url>
 
-	<licenses>
-		<license>
-			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-		</license>
-	</licenses>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
 
-	<developers>
-		<developer>
-			<name>Dewey Jose</name>
-			<email>richard.e.jose@gmail.com</email>
-			<organization>dj</organization>
-		</developer>
-	</developers>
+  <developers>
+    <developer>
+      <name>Dewey Jose</name>
+      <email>richard.e.jose@gmail.com</email>
+      <organization>dj</organization>
+    </developer>
+  </developers>
 
-	<scm>
-		<connection>scm:git:git@github.com:deweyjose/graphqlcodegen.git</connection>
-		<url>scm:git:git@github.com:deweyjose/graphqlcodegen.git</url>
-		<developerConnection>scm:git:git@github.com:deweyjose/graphqlcodegen.git</developerConnection>
-	</scm>
+  <scm>
+    <connection>scm:git:git@github.com:deweyjose/graphqlcodegen.git</connection>
+    <url>scm:git:git@github.com:deweyjose/graphqlcodegen.git</url>
+    <developerConnection>scm:git:git@github.com:deweyjose/graphqlcodegen.git</developerConnection>
+  </scm>
 
-	<properties>
-		<graphql-dgs-codegen-core.version>6.0.2</graphql-dgs-codegen-core.version>
-		<java.version>1.8</java.version>
-		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-		<maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
-		<maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
-		<maven-plugin-plugin.version>3.6.1</maven-plugin-plugin.version>
-		<maven-plugin-api.version>3.8.1</maven-plugin-api.version>
-		<maven-plugin-annotations.version>3.6.1</maven-plugin-annotations.version>
-		<maven-project.version>2.2.1</maven-project.version>
-		<maven-release-plugin.version>3.0.0-M4</maven-release-plugin.version>
-		<maven-scm-provider-gitexe.version>1.11.2</maven-scm-provider-gitexe.version>
-		<nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+  <properties>
+    <graphql-dgs-codegen-core.version>6.0.2</graphql-dgs-codegen-core.version>
+    <java.version>1.8</java.version>
+    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+    <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
+    <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
+    <maven-plugin-plugin.version>3.6.1</maven-plugin-plugin.version>
+    <maven-plugin-api.version>3.8.1</maven-plugin-api.version>
+    <maven-plugin-annotations.version>3.6.1</maven-plugin-annotations.version>
+    <maven-project.version>2.2.1</maven-project.version>
+    <maven-release-plugin.version>3.0.0-M4</maven-release-plugin.version>
+    <maven-scm-provider-gitexe.version>1.11.2</maven-scm-provider-gitexe.version>
+    <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
     <junit.version>5.9.2</junit.version>
-	</properties>
+    <lombok.version>1.18.28</lombok.version>
+  </properties>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-plugin-api</artifactId>
-			<version>${maven-plugin-api.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.maven.plugin-tools</groupId>
-			<artifactId>maven-plugin-annotations</artifactId>
-			<version>${maven-plugin-annotations.version}</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-project</artifactId>
-			<version>${maven-project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.netflix.graphql.dgs.codegen</groupId>
-			<artifactId>graphql-dgs-codegen-core</artifactId>
-			<version>${graphql-dgs-codegen-core.version}</version>
-		</dependency>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>${maven-plugin-api.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>${maven-plugin-annotations.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-project</artifactId>
+      <version>${maven-project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.netflix.graphql.dgs.codegen</groupId>
+      <artifactId>graphql-dgs-codegen-core</artifactId>
+      <version>${graphql-dgs-codegen-core.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>${lombok.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.6</version>
+    </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
@@ -82,100 +95,100 @@
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
-	</dependencies>
+  </dependencies>
 
-	<distributionManagement>
-		<repository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-		</repository>
-	</distributionManagement>
+  <distributionManagement>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+    </repository>
+  </distributionManagement>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>${nexus-staging-maven-plugin.version}</version>
-				<extensions>true</extensions>
-				<configuration>
-					<serverId>ossrh</serverId>
-					<nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-					<autoReleaseAfterClose>true</autoReleaseAfterClose>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>${maven-compiler-plugin.version}</version>
-				<configuration>
-					<source>${java.version}</source>
-					<target>${java.version}</target>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-plugin-plugin</artifactId>
-				<version>${maven-plugin-plugin.version}</version>
-			</plugin>
-		</plugins>
-	</build>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>${nexus-staging-maven-plugin.version}</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>${maven-plugin-plugin.version}</version>
+      </plugin>
+    </plugins>
+  </build>
 
-	<profiles>
-		<profile>
-			<id>release</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-source-plugin</artifactId>
-						<version>3.2.1</version>
-						<executions>
-							<execution>
-								<id>attach-sources</id>
-								<goals>
-									<goal>jar-no-fork</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>3.3.1</version>
-						<executions>
-							<execution>
-								<id>attach-javadocs</id>
-								<goals>
-									<goal>jar</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-gpg-plugin</artifactId>
-						<version>${maven-gpg-plugin.version}</version>
-						<executions>
-							<execution>
-								<id>sign-artifacts</id>
-								<phase>verify</phase>
-								<goals>
-									<goal>sign</goal>
-								</goals>
-							</execution>
-						</executions>
-						<configuration>
-							<!-- Prevent gpg from using pinentry programs -->
-							<gpgArguments>
-								<arg>--pinentry-mode</arg>
-								<arg>loopback</arg>
-							</gpgArguments>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.2.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.3.1</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>${maven-gpg-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <!-- Prevent gpg from using pinentry programs -->
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
@@ -178,17 +178,6 @@ public class Codegen extends AbstractMojo {
 			}
 
 		}
-
-		for (final File schemaPath : schemaPaths) {
-			if (!schemaPath.exists()) {
-				try {
-					throw new RuntimeException(
-							format("Schema File: %s does not exist!", schemaPath.getCanonicalPath()));
-				} catch (final IOException e) {
-					e.printStackTrace();
-				}
-			}
-		}
 	}
 
 	@Override
@@ -196,6 +185,7 @@ public class Codegen extends AbstractMojo {
 		if (!skip) {
 
 			verifySettings();
+
 
 			// @formatter:off
 			final CodeGenConfig config = new CodeGenConfig(

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
@@ -1,29 +1,25 @@
 package io.github.deweyjose.graphqlcodegen;
 
-import static java.lang.String.format;
-import static java.util.Arrays.stream;
-import static java.util.Collections.emptySet;
-import static java.util.Objects.isNull;
-import static java.util.stream.Collectors.*;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Paths;
-import java.util.*;
-import java.util.Map.Entry;
-
+import com.netflix.graphql.dgs.codegen.CodeGen;
+import com.netflix.graphql.dgs.codegen.CodeGenConfig;
+import com.netflix.graphql.dgs.codegen.Language;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
-import com.netflix.graphql.dgs.codegen.CodeGen;
-import com.netflix.graphql.dgs.codegen.CodeGenConfig;
-import com.netflix.graphql.dgs.codegen.Language;
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.Map.Entry;
+
+import static java.lang.String.format;
+import static java.util.Arrays.stream;
+import static java.util.Collections.emptySet;
+import static java.util.Objects.isNull;
+import static java.util.stream.Collectors.*;
 
 @Mojo(name = "generate", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
 public class Codegen extends AbstractMojo {
@@ -176,12 +172,11 @@ public class Codegen extends AbstractMojo {
 			} else {
 				getLog().warn(String.format("Unable to find Artifact`%s`", jarDepClean));
 			}
-
 		}
 	}
 
 	@Override
-	public void execute() throws MojoExecutionException, MojoFailureException {
+	public void execute() {
 		if (!skip) {
 
 			verifySettings();

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
@@ -3,7 +3,6 @@ package io.github.deweyjose.graphqlcodegen;
 import com.netflix.graphql.dgs.codegen.CodeGen;
 import com.netflix.graphql.dgs.codegen.CodeGenConfig;
 import com.netflix.graphql.dgs.codegen.Language;
-import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -12,253 +11,273 @@ import org.apache.maven.project.MavenProject;
 
 import java.io.File;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import static java.lang.String.format;
 import static java.util.Arrays.stream;
 import static java.util.Collections.emptySet;
-import static java.util.Objects.isNull;
 import static java.util.stream.Collectors.*;
 
 @Mojo(name = "generate", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
 public class Codegen extends AbstractMojo {
 
-	@Parameter(defaultValue = "${project}")
-	private MavenProject project;
+  @Parameter(defaultValue = "${project}")
+  private MavenProject project;
 
-	@Parameter(property = "schemaPaths")
-	private File[] schemaPaths;
+  @Parameter(property = "schemaPaths")
+  private File[] schemaPaths;
 
-	@Parameter(alias = "schemaJarFilesFromDependencies", property = "schemaJarFilesFromDependencies")
-	private String[] schemaJarFilesFromDependencies;
-	private final List<File> schemaJarFilesFromDependenciesFiles = new ArrayList<>();
+  @Parameter(alias = "schemaJarFilesFromDependencies", property = "schemaJarFilesFromDependencies")
+  private String[] schemaJarFilesFromDependencies;
 
-	@Parameter(property = "packageName", defaultValue = "")
-	private String packageName;
+  @Parameter(property = "packageName", defaultValue = "")
+  private String packageName;
 
-	@Parameter(property = "subPackageNameClient", defaultValue = "client")
-	private String subPackageNameClient;
+  @Parameter(property = "subPackageNameClient", defaultValue = "client")
+  private String subPackageNameClient;
 
-	@Parameter(property = "subPackageNameDatafetchers", defaultValue = "datafetchers")
-	private String subPackageNameDatafetchers;
+  @Parameter(property = "subPackageNameDatafetchers", defaultValue = "datafetchers")
+  private String subPackageNameDatafetchers;
 
-	@Parameter(property = "subPackageNameTypes", defaultValue = "types")
-	private String subPackageNameTypes;
+  @Parameter(property = "subPackageNameTypes", defaultValue = "types")
+  private String subPackageNameTypes;
 
-	@Parameter(property = "subPackageNameDocs", defaultValue = "docs")
-	private String subPackageNameDocs;
+  @Parameter(property = "subPackageNameDocs", defaultValue = "docs")
+  private String subPackageNameDocs;
 
-	@Parameter(property = "language", defaultValue = "java")
-	private String language;
+  @Parameter(property = "language", defaultValue = "java")
+  private String language;
 
-	@Parameter(property = "typeMapping")
-	private Map<String, String> typeMapping;
+  @Parameter(property = "typeMapping")
+  private Map<String, String> typeMapping;
 
-	@Parameter(property = "generateBoxedTypes", defaultValue = "false")
-	private boolean generateBoxedTypes;
+  @Parameter(property = "generateBoxedTypes", defaultValue = "false")
+  private boolean generateBoxedTypes;
 
-	@Parameter(property = "generateClientApi", defaultValue = "false")
-	private boolean generateClientApi;
+  @Parameter(property = "generateClientApi", defaultValue = "false")
+  private boolean generateClientApi;
 
-	@Parameter(property = "generateClientApiV2", defaultValue = "false")
-	private boolean generateClientApiV2;
+  @Parameter(property = "generateClientApiV2", defaultValue = "false")
+  private boolean generateClientApiV2;
 
-	@Parameter(property = "generateDataTypes", defaultValue = "true")
-	private boolean generateDataTypes;
+  @Parameter(property = "generateDataTypes", defaultValue = "true")
+  private boolean generateDataTypes;
 
-	@Parameter(property = "generateInterfaces", defaultValue = "false")
-	private boolean generateInterfaces;
+  @Parameter(property = "generateInterfaces", defaultValue = "false")
+  private boolean generateInterfaces;
 
-	@Parameter(property = "generateKotlinNullableClasses", defaultValue = "false")
-	private boolean generateKotlinNullableClasses;
+  @Parameter(property = "generateKotlinNullableClasses", defaultValue = "false")
+  private boolean generateKotlinNullableClasses;
 
-	@Parameter(property = "generateKotlinClosureProjections", defaultValue = "false")
-	private boolean generateKotlinClosureProjections;
+  @Parameter(property = "generateKotlinClosureProjections", defaultValue = "false")
+  private boolean generateKotlinClosureProjections;
 
-	@Parameter(property = "outputDir", defaultValue = "${project.build.directory}/generated-sources")
-	private File outputDir;
+  @Parameter(property = "outputDir", defaultValue = "${project.build.directory}/generated-sources")
+  private File outputDir;
 
-	@Parameter(property = "exampleOutputDir", defaultValue = "${project.build.directory}/generated-examples")
-	private File exampleOutputDir;
+  @Parameter(property = "exampleOutputDir", defaultValue = "${project.build.directory}/generated-examples")
+  private File exampleOutputDir;
 
-	@Parameter(property = "includeQueries")
-	private String[] includeQueries;
+  @Parameter(property = "includeQueries")
+  private String[] includeQueries;
 
-	@Parameter(property = "includeMutations")
-	private String[] includeMutations;
+  @Parameter(property = "includeMutations")
+  private String[] includeMutations;
 
-	@Parameter(property = "skipEntityQueries", defaultValue = "false")
-	private boolean skipEntityQueries;
+  @Parameter(property = "skipEntityQueries", defaultValue = "false")
+  private boolean skipEntityQueries;
 
-	@Parameter(property = "shortProjectionNames", defaultValue = "false")
-	private boolean shortProjectionNames;
+  @Parameter(property = "shortProjectionNames", defaultValue = "false")
+  private boolean shortProjectionNames;
 
-	@Parameter(property = "maxProjectionDepth", defaultValue = "10")
-	private int maxProjectionDepth;
+  @Parameter(property = "maxProjectionDepth", defaultValue = "10")
+  private int maxProjectionDepth;
 
-	@Parameter(property = "omitNullInputFields", defaultValue = "false")
-	private boolean omitNullInputFields;
+  @Parameter(property = "omitNullInputFields", defaultValue = "false")
+  private boolean omitNullInputFields;
 
-	@Parameter(property = "kotlinAllFieldsOptional", defaultValue = "false")
-	private boolean kotlinAllFieldsOptional;
+  @Parameter(property = "kotlinAllFieldsOptional", defaultValue = "false")
+  private boolean kotlinAllFieldsOptional;
 
-	@Parameter(property = "snakeCaseConstantNames", defaultValue = "false")
-	private boolean snakeCaseConstantNames;
+  @Parameter(property = "snakeCaseConstantNames", defaultValue = "false")
+  private boolean snakeCaseConstantNames;
 
-	@Parameter(property = "writeToFiles", defaultValue = "true")
-	private boolean writeToFiles;
+  @Parameter(property = "writeToFiles", defaultValue = "true")
+  private boolean writeToFiles;
 
-	@Parameter(property = "includeSubscriptions")
-	private String[] includeSubscriptions;
+  @Parameter(property = "includeSubscriptions")
+  private String[] includeSubscriptions;
 
-	@Parameter(property = "generateInterfaceSetters", defaultValue = "false")
-	private boolean generateInterfaceSetters;
+  @Parameter(property = "generateInterfaceSetters", defaultValue = "false")
+  private boolean generateInterfaceSetters;
 
-	@Parameter(property = "generateInterfaceMethodsForInterfaceFields", defaultValue = "false")
-	private boolean generateInterfaceMethodsForInterfaceFields;
+  @Parameter(property = "generateInterfaceMethodsForInterfaceFields", defaultValue = "false")
+  private boolean generateInterfaceMethodsForInterfaceFields;
 
-	@Parameter(property = "generateDocs", defaultValue = "false")
-	private Boolean generateDocs;
+  @Parameter(property = "generateDocs", defaultValue = "false")
+  private Boolean generateDocs;
 
-	@Parameter(property = "generatedDocsFolder", defaultValue = "./generated-docs")
-	private String generatedDocsFolder;
+  @Parameter(property = "generatedDocsFolder", defaultValue = "./generated-docs")
+  private String generatedDocsFolder;
 
-	@Parameter(property = "javaGenerateAllConstructor", defaultValue = "false")
-	private boolean javaGenerateAllConstructor;
+  @Parameter(property = "javaGenerateAllConstructor", defaultValue = "false")
+  private boolean javaGenerateAllConstructor;
 
-	@Parameter(property = "implementSerializable", defaultValue = "false")
-	private boolean implementSerializable;
+  @Parameter(property = "implementSerializable", defaultValue = "false")
+  private boolean implementSerializable;
 
-	@Parameter(property = "addGeneratedAnnotation", defaultValue = "false")
-	private boolean addGeneratedAnnotation;
+  @Parameter(property = "addGeneratedAnnotation", defaultValue = "false")
+  private boolean addGeneratedAnnotation;
 
-	@Parameter(property = "addDeprecatedAnnotation", defaultValue = "false")
-	private boolean addDeprecatedAnnotation;
+  @Parameter(property = "addDeprecatedAnnotation", defaultValue = "false")
+  private boolean addDeprecatedAnnotation;
 
-	@Parameter(property = "dgs.codegen.skip", defaultValue = "false", required = false)
-	private boolean skip;
+  @Parameter(property = "dgs.codegen.skip", defaultValue = "false", required = false)
+  private boolean skip;
 
-	@Parameter(property = "generateCustomAnnotations", defaultValue = "false")
-	private boolean generateCustomAnnotations;
+  @Parameter(property = "generateCustomAnnotations", defaultValue = "false")
+  private boolean generateCustomAnnotations;
 
-	@Parameter(property = "includeImports")
-	private Map<String, String> includeImports;
+  @Parameter(property = "includeImports")
+  private Map<String, String> includeImports;
 
-	@Parameter(property = "includeEnumImports")
-	private Map<String, Properties> includeEnumImports;
+  @Parameter(property = "includeEnumImports")
+  private Map<String, Properties> includeEnumImports;
 
-	@Parameter(property = "includeClassImports")
-	private Map<String, Properties> includeClassImports;
+  @Parameter(property = "includeClassImports")
+  private Map<String, Properties> includeClassImports;
 
-	private void verifySettings() {
-		if (isNull(packageName)) {
-			throw new RuntimeException("Please specify a packageName");
-		}
+  @Parameter(property = "onlyGenerateChanged", defaultValue = "true")
+  private boolean onlyGenerateChanged;
 
-		Validations.verifySchemaPaths(Arrays.stream(schemaPaths).collect(toList()));
+  private void verifySettings() {
+    Validations.verifyPackageName(packageName);
+    Validations.verifySchemaPaths(Arrays.stream(schemaPaths).collect(toList()));
+  }
 
-		for (final String jarDep : schemaJarFilesFromDependencies) {
-			final String jarDepClean = jarDep.trim();
-			if (jarDepClean.isEmpty()) {
-				continue;
-			}
+  /**
+   * Helper function that computes schema paths to generate.
+   * @return
+   */
+  private Set<File> getSchemaPaths() {
+    if (onlyGenerateChanged) {
+      Set<File> configuredSchemaPaths = stream(schemaPaths).collect(toSet());
+      Set<File> expandedSchemaPaths = new HashSet<>();
 
-			final Optional<Artifact> artifactOpt = findFromDependencies(jarDepClean);
-			if (artifactOpt.isPresent()) {
-				final Artifact artifact = artifactOpt.get();
-				final File file = artifact.getFile();
-				schemaJarFilesFromDependenciesFiles.add(file);
-			} else {
-				getLog().warn(String.format("Unable to find Artifact`%s`", jarDepClean));
-			}
-		}
-	}
+      // expand any directories into graphql file paths
+      for (File path : configuredSchemaPaths) {
+        if (path.isFile()) {
+          expandedSchemaPaths.add(path);
+        } else {
+          expandedSchemaPaths.addAll(SchemaFileManifest.findGraphQLSFiles(path));
+        }
+      }
 
-	@Override
-	public void execute() {
-		if (!skip) {
+      getLog().info(String.format("expanded schema paths: %s", expandedSchemaPaths));
+      return expandedSchemaPaths;
+    } else {
+      return stream(schemaPaths).collect(toSet());
+    }
+  }
 
-			verifySettings();
+  @Override
+  public void execute() {
+    if (!skip) {
 
+      verifySettings();
 
-			// @formatter:off
-			final CodeGenConfig config = new CodeGenConfig(
-				emptySet(),
-				stream(schemaPaths).collect(toSet()),
-				schemaJarFilesFromDependenciesFiles,
-				outputDir.toPath(),
-				exampleOutputDir.toPath(),
-				writeToFiles,
-				packageName,
-				subPackageNameClient,
-				subPackageNameDatafetchers,
-				subPackageNameTypes,
-				subPackageNameDocs,
-				Language.valueOf(language.toUpperCase()),
-				generateBoxedTypes,
-				generateClientApi,
-				generateClientApiV2,
-				generateInterfaces,
-				generateKotlinNullableClasses,
-				generateKotlinClosureProjections,
-				typeMapping,
-				stream(includeQueries).collect(toSet()),
-				stream(includeMutations).collect(toSet()),
-				stream(includeSubscriptions).collect(toSet()),
-				skipEntityQueries,
-				shortProjectionNames,
-				generateDataTypes,
-				omitNullInputFields,
-				maxProjectionDepth,
-				kotlinAllFieldsOptional,
-				snakeCaseConstantNames,
-				generateInterfaceSetters,
-				generateInterfaceMethodsForInterfaceFields,
-				generateDocs,
-				Paths.get(generatedDocsFolder),
-				includeImports,
-				includeEnumImports
-					.entrySet()
-					.stream()
-					.collect(toMap(
-						Entry::getKey,
-						entry -> entry.getValue().getProperties()
-					)),
-				includeClassImports
-					.entrySet()
-					.stream()
-					.collect(toMap(
-						Entry::getKey,
-						entry -> entry.getValue().getProperties()
-					)),
-				generateCustomAnnotations,
-				javaGenerateAllConstructor,
-				implementSerializable,
-				addGeneratedAnnotation,
-				addDeprecatedAnnotation
-			);
-      		// @formatter:on
+      Set<File> schemaPaths = getSchemaPaths();
 
-			getLog().info(format("Codegen config: %n%s", config));
+      SchemaFileManifest manifest = new SchemaFileManifest(
+        new File(outputDir, "schema-manifest.props")
+      );
 
-			final CodeGen codeGen = new CodeGen(config);
-			codeGen.generate();
-		}
-	}
+      if (onlyGenerateChanged) {
+        manifest.setFiles(new HashSet<>(schemaPaths));
+        schemaPaths.retainAll(manifest.getChangedFiles());
+        getLog().info(String.format("changed schema files: %s", schemaPaths));
+      }
 
-	private Optional<Artifact> findFromDependencies(final String artifactRef) {
-		final String cleanRef = artifactRef.trim();
-		final Set<Artifact> dependencyArtifacts = project.getDependencyArtifacts();
+      if (schemaPaths.isEmpty()) {
+        getLog().info("no files to generate");
+        return;
+      }
 
-		for (final Artifact artifact : dependencyArtifacts) {
-			final String ref = format("%s:%s:%s", artifact.getGroupId(), artifact.getArtifactId(),
-					artifact.getVersion());
+      final CodeGenConfig config = new CodeGenConfig(
+        emptySet(),
+        schemaPaths,
+        DependencySchemaExtractor.extract(
+          project,
+          schemaJarFilesFromDependencies
+        ),
+        outputDir.toPath(),
+        exampleOutputDir.toPath(),
+        writeToFiles,
+        packageName,
+        subPackageNameClient,
+        subPackageNameDatafetchers,
+        subPackageNameTypes,
+        subPackageNameDocs,
+        Language.valueOf(language.toUpperCase()),
+        generateBoxedTypes,
+        generateClientApi,
+        generateClientApiV2,
+        generateInterfaces,
+        generateKotlinNullableClasses,
+        generateKotlinClosureProjections,
+        typeMapping,
+        stream(includeQueries).collect(toSet()),
+        stream(includeMutations).collect(toSet()),
+        stream(includeSubscriptions).collect(toSet()),
+        skipEntityQueries,
+        shortProjectionNames,
+        generateDataTypes,
+        omitNullInputFields,
+        maxProjectionDepth,
+        kotlinAllFieldsOptional,
+        snakeCaseConstantNames,
+        generateInterfaceSetters,
+        generateInterfaceMethodsForInterfaceFields,
+        generateDocs,
+        Paths.get(generatedDocsFolder),
+        includeImports,
+        includeEnumImports
+          .entrySet()
+          .stream()
+          .collect(toMap(
+            Entry::getKey,
+            entry -> entry.getValue().getProperties()
+          )),
+        includeClassImports
+          .entrySet()
+          .stream()
+          .collect(toMap(
+            Entry::getKey,
+            entry -> entry.getValue().getProperties()
+          )),
+        generateCustomAnnotations,
+        javaGenerateAllConstructor,
+        implementSerializable,
+        addGeneratedAnnotation,
+        addDeprecatedAnnotation
+      );
 
-			if (ref.equals(cleanRef)) {
-				return Optional.of(artifact);
-			}
-		}
-		return Optional.empty();
-	}
+      getLog().info(format("Codegen config: %n%s", config));
+
+      final CodeGen codeGen = new CodeGen(config);
+      codeGen.generate();
+
+      if (onlyGenerateChanged) {
+        try {
+          manifest.syncManifest();
+        } catch (Exception e) {
+          getLog().warn("error syncing manifest", e);
+        }
+      }
+    }
+  }
 }

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/DependencySchemaExtractor.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/DependencySchemaExtractor.java
@@ -1,0 +1,51 @@
+package io.github.deweyjose.graphqlcodegen;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.project.MavenProject;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.lang.String.format;
+
+// @@@ TODO: unit tests
+
+public class DependencySchemaExtractor {
+  public static List<File> extract(MavenProject project, String[] schemaJarFilesFromDependencies) {
+    List<File> files = new ArrayList<>();
+
+    for (final String jarDep : schemaJarFilesFromDependencies) {
+      final String jarDepClean = jarDep.trim();
+      if (jarDepClean.isEmpty()) {
+        continue;
+      }
+
+      final Optional<Artifact> artifactOpt = findFromDependencies(project, jarDepClean);
+      if (artifactOpt.isPresent()) {
+        final Artifact artifact = artifactOpt.get();
+        final File file = artifact.getFile();
+        files.add(file);
+      }
+    }
+
+    return files;
+  }
+
+  private static Optional<Artifact> findFromDependencies(MavenProject project, final String artifactRef) {
+    final String cleanRef = artifactRef.trim();
+    final Set<Artifact> dependencyArtifacts = project.getDependencyArtifacts();
+
+    for (final Artifact artifact : dependencyArtifacts) {
+      final String ref = format("%s:%s:%s", artifact.getGroupId(), artifact.getArtifactId(),
+        artifact.getVersion());
+
+      if (ref.equals(cleanRef)) {
+        return Optional.of(artifact);
+      }
+    }
+    return Optional.empty();
+  }
+}

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/Properties.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/Properties.java
@@ -1,8 +1,8 @@
 package io.github.deweyjose.graphqlcodegen;
 
-import java.util.Map;
-
 import org.apache.maven.plugins.annotations.Parameter;
+
+import java.util.Map;
 
 public class Properties {
 	@Parameter

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/SchemaFileManifest.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/SchemaFileManifest.java
@@ -1,0 +1,134 @@
+package io.github.deweyjose.graphqlcodegen;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.util.*;
+import java.util.Properties;
+
+@Slf4j
+public class SchemaFileManifest {
+  private Set<File> files;
+  private Properties manifest;
+  private File manifestPath;
+
+  /**
+   * Manifest constructor loads the properties file into memory.
+   * The properties file has a property for each path with the
+   * previous known checksum.
+   * @param files
+   * @param manifestPath
+   */
+  public SchemaFileManifest(Set<File> files, File manifestPath) {
+    this.files = files;
+    this.manifestPath = manifestPath;
+    manifest = loadManifest(manifestPath);
+  }
+
+  public SchemaFileManifest(File manifestPath) {
+    this.manifestPath = manifestPath;
+    manifest = loadManifest(manifestPath);
+  }
+
+  public void setFiles(Set<File> files) {
+    this.files = files;
+  }
+
+  /**
+   * Computes the Set of files that have changed or are new
+   * and need to trigger code generation.
+   * @return Set<File>
+   */
+  public Set<File> getChangedFiles() {
+    Set<File> changed = new HashSet<>();
+    for (File file : files) {
+      String oldChecksum = manifest.getProperty(file.getPath());
+      if (oldChecksum == null) {
+        log.info("{} is new, will generate code", file.getName());
+      } else if (!oldChecksum.equals(generateChecksum(file))) {
+        log.info("{} has changed, will generate code", file.getName());
+      } else {
+        log.info("{} has not changed, will not generate code", file.getName());
+        continue;
+      }
+      changed.add(file);
+    }
+    return changed;
+  }
+
+  /**
+   * Clear the old manifest, compute new checksums
+   * for each file and save the properties file.
+   */
+  @SneakyThrows
+  public void syncManifest() {
+    manifest.clear();
+    for (File file : files) {
+      manifest.put(file.getPath(), generateChecksum(file));
+    }
+
+    try (FileOutputStream fos = new FileOutputStream(manifestPath)) {
+      manifest.store(fos, "Schema Manifest");
+      fos.flush();
+    }
+  }
+
+  @SneakyThrows
+  public static Properties loadManifest(File manifestPath) {
+    Properties properties = new Properties();
+    if (manifestPath.exists()) {
+      try (FileInputStream fis = new FileInputStream(manifestPath)) {
+        properties.load(fis);
+      }
+    }
+    return properties;
+  }
+
+  @SneakyThrows
+  public static String generateChecksum(File path) {
+    byte[] data = Files.readAllBytes(Paths.get(path.toURI()));
+    byte[] hash = MessageDigest.getInstance("MD5").digest(data);
+    String checksum = new BigInteger(1, hash).toString(16);
+    return checksum;
+  }
+
+  /**
+   * We only care about files ending with .graphql(s)
+   * @param file
+   * @return boolean
+   */
+  public static boolean isGraphqlFile(File file) {
+    return file.getName().endsWith(".graphqls") ||
+      file.getName().endsWith(".graphql");
+  }
+
+  /**
+   * Traverse the directory structure collecting .graphql(s) files.
+   * @param directory
+   * @return Set<File>
+   */
+  public static Set<File> findGraphQLSFiles(File directory) {
+    Set<File> result = new HashSet<>();
+
+    File[] contents = directory.listFiles();
+    if (contents != null) {
+      for (File content : contents) {
+        if (content.isFile() && isGraphqlFile(content)) {
+          result.add(content);
+        } else if (content.isDirectory()) {
+          Set<File> subdirectoryGraphQLSFiles = findGraphQLSFiles(content);
+          result.addAll(subdirectoryGraphQLSFiles);
+        }
+      }
+    }
+
+    return result;
+  }
+}

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/Validations.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/Validations.java
@@ -29,6 +29,10 @@ public class Validations {
     Set<String> encounteredPaths = new HashSet<>();
 
     for (File file : sortedFiles) {
+      if (!file.exists()) {
+        throw new IllegalArgumentException("Configured path %s does not exist" + file.getPath());
+      }
+
       String path = file.getPath();
 
       // Check for directory overlap

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/Validations.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/Validations.java
@@ -3,7 +3,19 @@ package io.github.deweyjose.graphqlcodegen;
 import java.io.File;
 import java.util.*;
 
+import static java.util.Objects.isNull;
+
 public class Validations {
+
+  /**
+   * Ensures the package name isn't null.
+   * @param name
+   */
+  public static void verifyPackageName(String name) {
+    if (isNull(name)) {
+      throw new IllegalArgumentException("Please specify a packageName");
+    }
+  }
 
   /**
    * We sort the input files by their paths to ensure a consistent order for processing.

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,27 @@
+<configuration>
+  # Console appender
+  <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+    <layout class="ch.qos.logback.classic.PatternLayout">
+      # Pattern of log message for console appender
+      <Pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %m%n</Pattern>
+    </layout>
+  </appender>
+
+  # File appender
+  <appender name="fout" class="ch.qos.logback.core.FileAppender">
+    <file>baeldung.log</file>
+    <append>false</append>
+    <encoder>
+      # Pattern of log message for file appender
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %m%n</pattern>
+    </encoder>
+  </appender>
+
+  # Override log level for specified package
+  <logger name="com.baeldung.log4j" level="TRACE"/>
+
+  <root level="INFO">
+    <appender-ref ref="stdout" />
+    <appender-ref ref="fout" />
+  </root>
+</configuration>

--- a/src/test/java/io/github/deweyjose/graphqlcodegen/SchemaFileManifestTest.java
+++ b/src/test/java/io/github/deweyjose/graphqlcodegen/SchemaFileManifestTest.java
@@ -1,0 +1,118 @@
+package io.github.deweyjose.graphqlcodegen;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static io.github.deweyjose.graphqlcodegen.SchemaFileManifest.generateChecksum;
+import static junit.framework.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Slf4j
+class SchemaFileManifestTest {
+
+  @TempDir
+  Path tempFolder;
+
+  @Test
+  void testFindGraphqlFiles() {
+    File directory = getFile("schema");
+    Set<File> files = SchemaFileManifest.findGraphQLSFiles(directory);
+    assertEquals(4, files.size());
+  }
+
+  @Test
+  void testIsGraphqlFile() {
+    assertTrue(SchemaFileManifest.isGraphqlFile(new File("abc/foo.graphql")));
+    assertTrue(SchemaFileManifest.isGraphqlFile(new File("abc/foo.graphqls")));
+    assertFalse(SchemaFileManifest.isGraphqlFile(new File("abc/foo.graph")));
+    assertFalse(SchemaFileManifest.isGraphqlFile(new File("abc")));
+  }
+
+  @SneakyThrows
+  @Test
+  void testManifestNoChange() {
+
+    File bar = getFile("schema/bar.graphqls");
+    File foo = getFile("schema/foo.graphqls");
+
+    Properties properties = new Properties();
+    properties.put(bar.getPath(), "7cada13b5b8770e46f7a69e8856abdb9");
+    properties.put(foo.getPath(), "61bbd2d58c22dfb3c664829ad116f7e9");
+
+    File manifest = tempFolder.resolve("manifest.props").toFile();
+    try (FileOutputStream fis = new FileOutputStream(manifest)) {
+      properties.store(fis, "Schema Manifest");
+    }
+
+    SchemaFileManifest sfm = new SchemaFileManifest(new HashSet<>(Arrays.asList(foo, bar)), manifest);
+
+    Assertions.assertTrue(sfm.getChangedFiles().isEmpty());
+
+    sfm.syncManifest();
+
+    sfm = new SchemaFileManifest(new HashSet<>(Arrays.asList(foo, bar)), manifest);
+
+    Assertions.assertTrue(sfm.getChangedFiles().isEmpty());
+  }
+
+  @SneakyThrows
+  @Test
+  void testManifestRequiresChange() {
+
+    File bar = getFile("schema/bar.graphqls");
+    File foo = getFile("schema/foo.graphqls");
+    File manifest = tempFolder.resolve("manifest.props").toFile();
+
+    SchemaFileManifest sfm = new SchemaFileManifest(new HashSet<>(Arrays.asList(foo, bar)), manifest);
+
+    Assertions.assertTrue(sfm.getChangedFiles().contains(foo));
+
+    sfm.syncManifest();
+    Assertions.assertTrue(sfm.getChangedFiles().isEmpty());
+
+    sfm = new SchemaFileManifest(new HashSet<>(Arrays.asList(foo, bar)), manifest);
+    Assertions.assertTrue(sfm.getChangedFiles().isEmpty());
+    sfm.syncManifest();
+
+    sfm = new SchemaFileManifest(new HashSet<>(Arrays.asList(foo, bar)), manifest);
+    Assertions.assertTrue(sfm.getChangedFiles().isEmpty());
+  }
+
+  @ParameterizedTest
+  @MethodSource("checksumProvider")
+  void testChecksum(File file, String checksum) {
+    assertEquals(checksum, generateChecksum(file));
+  }
+
+  /**
+   * wrapper for resource File objects
+   * @param path
+   * @return File
+   */
+  private static File getFile(String path) {
+    return new File(ValidationsTest.class.getClassLoader().getResource(path).getFile());
+  }
+
+  private static Stream<Arguments> checksumProvider() {
+    return Stream.of(
+      Arguments.of(getFile("schema/bar.graphqls"), "7cada13b5b8770e46f7a69e8856abdb9"),
+      Arguments.of(getFile("schema/foo.graphqls"), "61bbd2d58c22dfb3c664829ad116f7e9")
+    );
+  }
+}

--- a/src/test/java/io/github/deweyjose/graphqlcodegen/ValidationsTest.java
+++ b/src/test/java/io/github/deweyjose/graphqlcodegen/ValidationsTest.java
@@ -78,6 +78,13 @@ class ValidationsTest {
   private static Stream<Arguments> overlappingFileListProvider() {
     return Stream.of(
       Arguments.of(Arrays.asList(
+        new File("schema"),
+        new File("schema/bars")
+      )),
+      Arguments.of(Arrays.asList(
+        new File("schema/a.graphqls")
+      )),
+      Arguments.of(Arrays.asList(
         getFile("schema"),
         getFile("schema/bar")
       )),

--- a/src/test/java/io/github/deweyjose/graphqlcodegen/ValidationsTest.java
+++ b/src/test/java/io/github/deweyjose/graphqlcodegen/ValidationsTest.java
@@ -1,6 +1,7 @@
 package io.github.deweyjose.graphqlcodegen;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -11,6 +12,20 @@ import java.util.List;
 import java.util.stream.Stream;
 
 class ValidationsTest {
+
+  @Test
+  void testNullPackageName() {
+    Assertions.assertThrows(
+      IllegalArgumentException.class,
+      () -> Validations.verifyPackageName(null),
+      "should fail"
+    );
+  }
+
+  @Test
+  void testValidPackageName() {
+    Assertions.assertDoesNotThrow(() -> Validations.verifyPackageName("foo"));
+  }
 
   @ParameterizedTest
   @MethodSource("happyPathFileListProvider")

--- a/src/test/resources/schema/bar.graphqls
+++ b/src/test/resources/schema/bar.graphqls
@@ -1,0 +1,5 @@
+type Actor {
+  id: Int!
+  name: String!
+  yob: Int!
+}

--- a/src/test/resources/schema/foo.graphqls
+++ b/src/test/resources/schema/foo.graphqls
@@ -1,0 +1,23 @@
+type Query {
+    shows(titleFilter: String): [Show]
+    bars(foo: Int): Foo
+}
+
+type Mutation {
+   createShow(showInput: ShowInput!): Show
+}
+
+type Show {
+    id: Int!
+    title: String
+    releaseYear: Int
+}
+
+input ShowInput {
+    title: String!
+    releaseYear: Int!
+}
+
+type Foo {
+    id: Int
+}


### PR DESCRIPTION
Added the ability to only generate code for schema files that have changed. Today this only works with `schemaPaths`. A subsequent release for schema compilation via dependencies will be release soon.

TLDR; All configured `schemaPaths` directories are expanded to the full set of .graphql(s) files in addition to any explicitly configured .graphqls files. A manifest file is maintained containing all the .graphqls files and their checksums. If a checksum matches - that file is removed from the set passed to codegen. If there are no files to process the codegen core code is not invoked.

This behavior is enabled by default. To disable: `<onlyGenerateChanged>false</onlyGenerateChanged>`

fixes #93 