### PR TITLE
feat: integrate dgs codegen 6.1.1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,7 @@
 root = true
 
 [*]
+max_line_length = 120
 indent_style = space
 indent_size = 4
 end_of_line = lf

--- a/README.md
+++ b/README.md
@@ -581,6 +581,21 @@ Maps the custom annotation and class names to the class packages. Only used when
     </bar>
 </includeClassImports>
 ```
+
+
+## generateIsGetterForPrimitiveBooleanFields
+
+- Type: boolean
+- Required: false
+- Default: false
+
+Example
+
+```xml
+<generateIsGetterForPrimitiveBooleanFields>false</generateIsGetterForPrimitiveBooleanFields>
+```
+
+
 # Usage
 
 Add the following to your pom files build/plugins section.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>io.github.deweyjose</groupId>
   <artifactId>graphqlcodegen-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>1.50</version>
+  <version>1.51.0</version>
 
   <name>GraphQL Code Generator</name>
   <description>Maven port of the Netflix DGS GraphQL Codegen gradle build plugin</description>
@@ -34,7 +34,7 @@
   </scm>
 
   <properties>
-    <graphql-dgs-codegen-core.version>6.0.2</graphql-dgs-codegen-core.version>
+    <graphql-dgs-codegen-core.version>6.1.1</graphql-dgs-codegen-core.version>
     <java.version>1.8</java.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
@@ -154,6 +154,9 @@ public class Codegen extends AbstractMojo {
     @Parameter(property = "onlyGenerateChanged", defaultValue = "true")
     private boolean onlyGenerateChanged;
 
+    @Parameter(property = "generateIsGetterForPrimitiveBooleanFields", defaultValue = "false")
+    private boolean generateIsGetterForPrimitiveBooleanFields;
+
     private void verifySettings() {
         Validations.verifyPackageName(packageName);
         Validations.verifySchemaPaths(Arrays.stream(schemaPaths).collect(toList()));
@@ -206,7 +209,50 @@ public class Codegen extends AbstractMojo {
                 return;
             }
 
-            final CodeGenConfig config = new CodeGenConfig(emptySet(), schemaPaths, DependencySchemaExtractor.extract(project, schemaJarFilesFromDependencies), outputDir.toPath(), exampleOutputDir.toPath(), writeToFiles, packageName, subPackageNameClient, subPackageNameDatafetchers, subPackageNameTypes, subPackageNameDocs, Language.valueOf(language.toUpperCase()), generateBoxedTypes, generateClientApi, generateClientApiV2, generateInterfaces, generateKotlinNullableClasses, generateKotlinClosureProjections, typeMapping, stream(includeQueries).collect(toSet()), stream(includeMutations).collect(toSet()), stream(includeSubscriptions).collect(toSet()), skipEntityQueries, shortProjectionNames, generateDataTypes, omitNullInputFields, maxProjectionDepth, kotlinAllFieldsOptional, snakeCaseConstantNames, generateInterfaceSetters, generateInterfaceMethodsForInterfaceFields, generateDocs, Paths.get(generatedDocsFolder), includeImports, includeEnumImports.entrySet().stream().collect(toMap(Entry::getKey, entry -> entry.getValue().getProperties())), includeClassImports.entrySet().stream().collect(toMap(Entry::getKey, entry -> entry.getValue().getProperties())), generateCustomAnnotations, javaGenerateAllConstructor, implementSerializable, addGeneratedAnnotation, addDeprecatedAnnotation);
+            final CodeGenConfig config = new CodeGenConfig(
+                emptySet(),
+                schemaPaths,
+                DependencySchemaExtractor.extract(project, schemaJarFilesFromDependencies),
+                outputDir.toPath(),
+                exampleOutputDir.toPath(),
+                writeToFiles,
+                packageName,
+                subPackageNameClient,
+                subPackageNameDatafetchers,
+                subPackageNameTypes,
+                subPackageNameDocs,
+                Language.valueOf(language.toUpperCase()),
+                generateBoxedTypes,
+                generateIsGetterForPrimitiveBooleanFields,
+                generateClientApi,
+                generateClientApiV2,
+                generateInterfaces,
+                generateKotlinNullableClasses,
+                generateKotlinClosureProjections,
+                typeMapping,
+                stream(includeQueries).collect(toSet()),
+                stream(includeMutations).collect(toSet()),
+                stream(includeSubscriptions).collect(toSet()),
+                skipEntityQueries,
+                shortProjectionNames,
+                generateDataTypes,
+                omitNullInputFields,
+                maxProjectionDepth,
+                kotlinAllFieldsOptional,
+                snakeCaseConstantNames,
+                generateInterfaceSetters,
+                generateInterfaceMethodsForInterfaceFields,
+                generateDocs,
+                Paths.get(generatedDocsFolder),
+                includeImports,
+                includeEnumImports.entrySet().stream().collect(toMap(Entry::getKey, entry -> entry.getValue().getProperties())),
+                includeClassImports.entrySet().stream().collect(toMap(Entry::getKey, entry -> entry.getValue().getProperties())),
+                generateCustomAnnotations,
+                javaGenerateAllConstructor,
+                implementSerializable,
+                addGeneratedAnnotation,
+                addDeprecatedAnnotation
+            );
 
             getLog().info(format("Codegen config: %n%s", config));
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -7,21 +7,7 @@
     </layout>
   </appender>
 
-  # File appender
-  <appender name="fout" class="ch.qos.logback.core.FileAppender">
-    <file>baeldung.log</file>
-    <append>false</append>
-    <encoder>
-      # Pattern of log message for file appender
-      <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %m%n</pattern>
-    </encoder>
-  </appender>
-
-  # Override log level for specified package
-  <logger name="com.baeldung.log4j" level="TRACE"/>
-
   <root level="INFO">
     <appender-ref ref="stdout" />
-    <appender-ref ref="fout" />
   </root>
 </configuration>


### PR DESCRIPTION
Integrate the latest version of DGS codegen and add support for the `generateIsGetterForPrimitiveBooleanFields` option.