### PR TITLE
fix: fix kotlin code generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.deweyjose</groupId>
     <artifactId>graphqlcodegen-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.51.1</version>
+    <version>1.51.2</version>
 
     <name>GraphQL Code Generator</name>
     <description>Maven port of the Netflix DGS GraphQL Codegen gradle build plugin</description>
@@ -51,9 +51,15 @@
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <junit.version>5.10.1</junit.version>
         <lombok.version>1.18.28</lombok.version>
+        <kotlinpoet-jvm.version>1.15.3</kotlinpoet-jvm.version>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>com.squareup</groupId>
+            <artifactId>kotlinpoet-jvm</artifactId>
+            <version>${kotlinpoet-jvm.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>


### PR DESCRIPTION
The plugin needs a dependency on kotlinpoet-jvm as kotlinpoet has become multiplatform. This fixes #116 . 