### PR TITLE
fix schemaJarFilesFromDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,9 @@ Example
 
 - Type: array
 - Required: false
-- Default:
-- Official doc : https://netflix.github.io/dgs/generating-code-from-schema/#generating-code-from-external-schemas-in-jars
+- Default: []
+- Official doc : https://netflix.github.io/dgs/generating-code-from-schema/#generating-code-from-external-schemas-in-jars.
+- Please note that `.graphql(s)` files must exist under the `META-INF` folder in the external jar file.
 
 Example
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.deweyjose</groupId>
     <artifactId>graphqlcodegen-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.60.0</version>
+    <version>1.60.1</version>
 
     <name>GraphQL Code Generator</name>
     <description>Maven port of the Netflix DGS GraphQL Codegen gradle build plugin</description>

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
@@ -15,12 +15,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.jar.JarFile;
 import java.util.zip.ZipEntry;
 
@@ -221,7 +217,7 @@ public class Codegen extends AbstractMojo {
                 getLog().info(String.format("changed schema files: %s", schemaPaths));
             }
 
-            if (schemaPaths.isEmpty()) {
+            if (schemaPaths.isEmpty() && schemaJarFilesFromDependencies.length < 1) {
                 getLog().info("no files to generate");
                 return;
             }
@@ -290,7 +286,7 @@ public class Codegen extends AbstractMojo {
                 addDeprecatedAnnotation
             );
 
-            getLog().info(format("Codegen config: %n%s", config));
+            getLog().info(format("Codegen config: \n%s", config));
 
             final CodeGen codeGen = new CodeGen(config);
             codeGen.generate();


### PR DESCRIPTION
- update documentation per Netflix DGS that `schemaJarFilesFromDependencies` requires the external .graphql(s) files to be packaged under `META-INF`
- fixed a small bug where if no local schemas were specified the plugin may not compile external schema files.