### PR TITLE
Update overview section in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Process:
 # Overview
 The DGS Code Generation plugin generates code for basic types and example data fetchers based on your Domain Graph
 Service's graphql schema file during the project's build process. The plugin requires the designated `packageName` for file generation.
-If no schema path is specified, it will look under src/resources/schema for
+If no `schemaPath` is specified, it will look in the src/main/resources/schema folder for
 any files with .graphqls extension.
 
 # Example Repo

--- a/README.md
+++ b/README.md
@@ -20,13 +20,10 @@ Process:
 
 
 # Overview
-The DGS Code Generation plugin generates code for basic types and example data fetchers based on the your Domain Graph
-Service's graphql schema file during the project's build process. The plugin requires the path to schema files and the
-package name to use to generate the file. If no schema path is specified, it will look under src/resources/schema for
-any files with .graphqls extension. plugin generates code for basic types and example data fetchers based on the your
-Domain Graph Service's graphql schema file during the project's build process. The plugin requires the path to schema
-files and the package name to use to generate the file. If no schema path is specified, it will look under
-src/resources/schema for any files with .graphqls extension.
+The DGS Code Generation plugin generates code for basic types and example data fetchers based on your Domain Graph
+Service's graphql schema file during the project's build process. The plugin requires the designated `packageName` for file generation.
+If no schema path is specified, it will look under src/resources/schema for
+any files with .graphqls extension.
 
 # Example Repo
 


### PR DESCRIPTION
The overview section of the Readme contained some duplicate sentences and did not really align with the actual implementation (e.g. schemaPath is not required and resource path was not correct).