### PR TITLE
Bumping dgs-codegen-core to 6.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.deweyjose</groupId>
     <artifactId>graphqlcodegen-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.60.1</version>
+    <version>1.61.0</version>
 
     <name>GraphQL Code Generator</name>
     <description>Maven port of the Netflix DGS GraphQL Codegen gradle build plugin</description>
@@ -35,7 +35,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <graphql-dgs-codegen-core.version>6.1.5</graphql-dgs-codegen-core.version>
+        <graphql-dgs-codegen-core.version>6.2.1</graphql-dgs-codegen-core.version>
         <java.version>1.8</java.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>


### PR DESCRIPTION
#### Intention
To use current features for the kotlin2 codegen, especially from 6.1.7 to be able to provide custom input serialiser.

#### What did change?
Bumping the version of dgs-codegen-code to the current 6.2.1