### PR TITLE
Scan properties files from classpath and fetch the mapping automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,6 +635,18 @@ Example
 <disableDatesInGeneratedAnnotation>true</disableDatesInGeneratedAnnotation>
 ```
 
+## propertiesFilePattern
+
+- Type: String
+- Required: false
+- Default: .*-typemapping\.properties$
+
+Example
+
+```xml
+<propertiesFilePattern>.*mapping.txt$</propertiesFilePattern>
+```
+
 # Usage
 
 Add the following to your pom files build/plugins section.

--- a/README.md
+++ b/README.md
@@ -644,7 +644,7 @@ This properties file pattern is used to scan and fetch type mapping properties i
 Example
 
 ```xml
-<propertiesFilePattern>.*mapping.txt$</propertiesFilePattern>
+<propertiesFilePattern>.*mapping.properties$</propertiesFilePattern>
 ```
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ Example
 ```
 
 ## propertiesFilePattern
-
+This properties file pattern is used to scan and fetch type mapping properties in the classpath. This configuration will be used only when typeMappingPropertiesFiles are not specified.
 - Type: String
 - Required: false
 - Default: .*-typemapping\.properties$

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.deweyjose</groupId>
     <artifactId>graphqlcodegen-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.61.5</version>
+    <version>1.61.6</version>
 
     <name>GraphQL Code Generator</name>
     <description>Maven port of the Netflix DGS GraphQL Codegen gradle build plugin</description>


### PR DESCRIPTION
This change scans for properties files in the classpath with pattern *-typemapping.properties and automatically fetches the mapping from them. This will remove the need to know the file paths and ensure that the mapping files are fetched even if they are not present in the maven plugin configuration. 

Please note that if the typeMappingPropertiesFiles are specified in the configuration, then this scanning is not done. This allows for exclusion of typemapping properties if they are not required.