### PR TITLE
Replace maven-project with maven-core 3.9.9 and update plugin version

### DIFF
--- a/graphqlcodegen-bootstrap-plugin/pom.xml
+++ b/graphqlcodegen-bootstrap-plugin/pom.xml
@@ -30,7 +30,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
+      <artifactId>maven-core</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/graphqlcodegen-maven-plugin/pom.xml
+++ b/graphqlcodegen-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <artifactId>graphqlcodegen-maven-plugin</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1</version>
   <packaging>maven-plugin</packaging>
 
   <name>GraphQL Code Generator Maven Plugin</name>
@@ -34,7 +34,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
+      <artifactId>maven-core</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/graphqlcodegen-maven-plugin/src/test/java/io/github/deweyjose/graphqlcodegen/services/SchemaFileServiceTest.java
+++ b/graphqlcodegen-maven-plugin/src/test/java/io/github/deweyjose/graphqlcodegen/services/SchemaFileServiceTest.java
@@ -1,7 +1,7 @@
 package io.github.deweyjose.graphqlcodegen.services;
 
-import static junit.framework.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,6 @@
     <maven-plugin-plugin.version>3.15.1</maven-plugin-plugin.version>
     <maven-plugin-api.version>3.9.9</maven-plugin-api.version>
     <maven-plugin-annotations.version>3.15.1</maven-plugin-annotations.version>
-    <maven-project.version>2.2.1</maven-project.version>
     <maven-release-plugin.version>3.0.0-M4</maven-release-plugin.version>
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
@@ -58,7 +57,8 @@
     <junit.version>5.12.2</junit.version>
     <lombok.version>1.18.38</lombok.version>
     <kotlinpoet-jvm.version>1.18.1</kotlinpoet-jvm.version>
-    <spotless.version>2.44.4</spotless.version>    
+    <spotless.version>2.44.4</spotless.version>
+    <maven-core.version>3.9.9</maven-core.version>
   </properties>
 
   <dependencyManagement>
@@ -85,8 +85,8 @@
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
-        <artifactId>maven-project</artifactId>
-        <version>${maven-project.version}</version>
+        <artifactId>maven-core</artifactId>
+        <version>${maven-core.version}</version>
       </dependency>
       <dependency>
         <groupId>com.netflix.graphql.dgs.codegen</groupId>


### PR DESCRIPTION
## Replace `maven-project` with `maven-core` 3.9.9

### Summary

This PR removes the legacy `org.apache.maven:maven-project` dependency from the codebase and replaces it with `org.apache.maven:maven-core` version 3.9.9. This aligns the project with current Maven best practices and ensures compatibility with modern Maven plugin development.

### Details

- **Dependencies:**
  - Removed all references to `maven-project` from the root and child POMs.
  - Added `maven-core` version 3.9.9 with the appropriate scope (`provided` where needed).
- **Plugin Version:**
  - Bumped the `graphqlcodegen-maven-plugin` version to `3.3.1` to reflect this change.
- **Test Fixes:**
  - Updated test imports in `SchemaFileServiceTest.java` to use JUnit Jupiter’s `assertFalse` instead of the deprecated JUnit 3 import.
- **Formatting:**
  - Applied Spotless to ensure code style consistency after import changes.

### Motivation

- `maven-core` is the recommended dependency for Maven plugin development, providing all necessary APIs and classes, while `maven-project` is outdated and redundant.
- Keeps the project up-to-date with the latest Maven ecosystem.
- Reduces potential for dependency conflicts and improves maintainability.

### How to Test

- Build the project with `mvn clean install` (tests and formatting should pass).
- Verify that all Maven plugins and codegen tasks work as expected.
