### PR TITLE
feat: add support for local type mapping properties files

### DIFF
--- a/graphqlcodegen-maven-plugin/pom.xml
+++ b/graphqlcodegen-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <artifactId>graphqlcodegen-maven-plugin</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0</version>
   <packaging>maven-plugin</packaging>
 
   <name>GraphQL Code Generator Maven Plugin</name>

--- a/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
+++ b/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
@@ -51,6 +51,9 @@ public class Codegen extends AbstractMojo implements CodegenConfigProvider {
   @Parameter(property = "typeMappingPropertiesFiles")
   private List<String> typeMappingPropertiesFiles;
 
+  @Parameter(property = "localTypeMappingPropertiesFiles")
+  private List<String> localTypeMappingPropertiesFiles;
+
   @Parameter(property = "dgs.codegen.skip", defaultValue = "false", required = false)
   private boolean skip;
 

--- a/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/CodegenConfigProvider.java
+++ b/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/CodegenConfigProvider.java
@@ -35,6 +35,11 @@ public interface CodegenConfigProvider {
   List<String> getTypeMappingPropertiesFiles();
 
   /**
+   * @return local type mapping properties files
+   */
+  List<String> getLocalTypeMappingPropertiesFiles();
+
+  /**
    * @return whether to skip code generation
    */
   boolean isSkip();

--- a/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/CodegenExecutor.java
+++ b/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/CodegenExecutor.java
@@ -74,7 +74,11 @@ public class CodegenExecutor {
 
     Map<String, String> typeMapping =
         typeMappingService.mergeTypeMapping(
-            request.getTypeMapping(), request.getTypeMappingPropertiesFiles(), artifacts);
+            request.getTypeMapping(),
+            request.getTypeMappingPropertiesFiles(),
+            request.getLocalTypeMappingPropertiesFiles(),
+            artifacts,
+            projectBaseDir);
 
     final CodeGenConfig config =
         new GeneratedCodeGenConfigBuilder()

--- a/graphqlcodegen-maven-plugin/src/test/java/io/github/deweyjose/graphqlcodegen/TestCodegenProvider.java
+++ b/graphqlcodegen-maven-plugin/src/test/java/io/github/deweyjose/graphqlcodegen/TestCodegenProvider.java
@@ -16,6 +16,7 @@ public class TestCodegenProvider implements CodegenConfigProvider {
   private File schemaManifestOutputDir = new File("target/test-schema-manifest");
   private boolean onlyGenerateChanged = false;
   private List<String> typeMappingPropertiesFiles = Collections.emptyList();
+  private List<String> localTypeMappingPropertiesFiles = Collections.emptyList();
   private boolean skip = false;
   private File outputDir = new File("target/generated-test-codegen");
   private File examplesOutputDir = outputDir;
@@ -113,6 +114,11 @@ public class TestCodegenProvider implements CodegenConfigProvider {
   @Override
   public List<String> getTypeMappingPropertiesFiles() {
     return typeMappingPropertiesFiles;
+  }
+
+  @Override
+  public List<String> getLocalTypeMappingPropertiesFiles() {
+    return localTypeMappingPropertiesFiles;
   }
 
   @Override


### PR DESCRIPTION
This PR adds support for local type mapping properties files, addressing issue #246. Changes: - Added new localTypeMappingPropertiesFiles parameter to support local type mapping files - Updated TypeMappingService to handle both local and JAR-based type mapping files - Added comprehensive tests for the new functionality - Updated all necessary interfaces and implementations. The changes allow users to specify type mapping files in two ways: 1. typeMappingPropertiesFiles - for files inside JAR dependencies 2. localTypeMappingPropertiesFiles - for files in the local project directory. Type mapping precedence (highest to lowest): 1. User-provided mappings 2. Local file mappings 3. JAR file mappings. Fixes #246