### PR TITLE
Add lifecycle-mapping-metadata.xml for m2e (Eclipse, VSCode)

### DIFF
--- a/graphqlcodegen-maven-plugin/pom.xml
+++ b/graphqlcodegen-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <artifactId>graphqlcodegen-maven-plugin</artifactId>
-  <version>3.5.0</version>
+  <version>3.5.1</version>
   <packaging>maven-plugin</packaging>
 
   <name>GraphQL Code Generator Maven Plugin</name>

--- a/graphqlcodegen-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/graphqlcodegen-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>generate</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <execute>
+          <runOnConfiguration>true</runOnConfiguration>
+        </execute>
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>


### PR DESCRIPTION
Hi!

This adds automatic configuration for M2E, the Maven integration for Eclipse which is also used in VSCode.
The plugin will be run during project update or full builds.
Especially, outputDir will be set as source folder by Eclipse.

Without this, users have to manually configure mappings, or at least disable autoAddSource and use builder-helper instead, both of which is cumbersome.

Thank you for this plugin!
