### PR TITLE
Fix #270: Update README.md to use correct property name generateClientApiv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Example
 <generateClientApi>false</generateClientApi>
 ```
 
-## generateClientApiV2
+## generateClientApiv2
 
 - Type: boolean
 - Required: false
@@ -344,7 +344,7 @@ Example
 
 ```xml
 
-<generateClientApiV2>false</generateClientApiV2>
+<generateClientApiv2>false</generateClientApiv2>
 ```
 
 ## generateInterfaces


### PR DESCRIPTION
This PR fixes the inconsistency between the property name in the code implementation and the README documentation, as reported in issue #270.

## Problem
The README.md was referencing generateClientApiV2 (uppercase V), but the actual code implementation uses generateClientApiv2 (lowercase v). This inconsistency caused user confusion when following the documentation, leading to errors during usage.

## Solution
Updated the README.md to use the correct property name generateClientApiv2 (lowercase v) to match the existing code implementation.

## Changes Made
- README.md: Changed section header and XML example to use generateClientApiv2 (lowercase v)
- No code changes required (implementation was already correct)

## Verification
- Documentation now matches the implementation
- Users following the README will use the correct property name
- Resolves the confusion mentioned in GitHub issue #270

Closes #270