### PR TITLE
fix build

### DIFF
--- a/graphqlcodegen-bootstrap-plugin/src/main/java/io/github/deweyjose/bootstrapcodegen/BuilderCodegen.java
+++ b/graphqlcodegen-bootstrap-plugin/src/main/java/io/github/deweyjose/bootstrapcodegen/BuilderCodegen.java
@@ -33,8 +33,10 @@ import org.jetbrains.kotlin.psi.KtPrimaryConstructor;
 @Mojo(name = "generate")
 public class BuilderCodegen extends AbstractMojo {
 
-  public static final String CODEGENCONFIG_URL =
-      "https://raw.githubusercontent.com/Netflix/dgs-codegen/master/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt";
+  @Parameter(
+      property = "graphql-dgs-codegen-core.version",
+      defaultValue = "${graphql-dgs-codegen-core.version}")
+  private String dgsCodegenVersion;
 
   @Parameter(
       property = "buildercodegen.outputDirectory",
@@ -45,14 +47,29 @@ public class BuilderCodegen extends AbstractMojo {
   public void execute() throws MojoExecutionException, MojoFailureException {
     getLog().info("Builder Code Generator Plugin");
     getLog().info("Output Directory: " + outputDirectory);
+    getLog().info("Using dgs-codegen version: " + dgsCodegenVersion);
 
     try {
-      String codeGenConfig = downloadCodeGenConfig(CODEGENCONFIG_URL);
+      String url = buildCodeGenConfigUrl(dgsCodegenVersion);
+      String codeGenConfig = downloadCodeGenConfig(url);
       KtParameter[] params = parseCodeGenConfigParameters(codeGenConfig);
       generateBuilderClass(params, outputDirectory);
     } catch (Exception e) {
       throw new MojoExecutionException("Failed to generate builder from CodeGenConfig.kt", e);
     }
+  }
+
+  /**
+   * Build the GitHub URL for CodeGen.kt based on the version.
+   *
+   * @param version The version of graphql-dgs-codegen-core (e.g., "8.1.1").
+   * @return The GitHub raw URL pointing to the versioned CodeGen.kt file.
+   */
+  private String buildCodeGenConfigUrl(String version) {
+    String tag = "v" + version;
+    return "https://raw.githubusercontent.com/Netflix/dgs-codegen/"
+        + tag
+        + "/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt";
   }
 
   /**

--- a/graphqlcodegen-bootstrap-plugin/src/test/java/io/github/deweyjose/bootstrapcodegen/BuilderCodegenTest.java
+++ b/graphqlcodegen-bootstrap-plugin/src/test/java/io/github/deweyjose/bootstrapcodegen/BuilderCodegenTest.java
@@ -11,7 +11,9 @@ class BuilderCodegenTest {
 
   @Test
   void testDownloadCodeGenConfig() throws Exception {
-    String url = BuilderCodegen.CODEGENCONFIG_URL;
+    // Use a versioned URL (v8.1.1) instead of master branch
+    String url =
+        "https://raw.githubusercontent.com/Netflix/dgs-codegen/v8.1.1/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt";
     String codeGenConfig = BuilderCodegen.downloadCodeGenConfig(url);
     assertNotNull(codeGenConfig, "CodeGenConfig should not be null");
     assertTrue(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make CodeGen.kt download version-aware via Maven parameter and update test to use a tagged URL.
> 
> - **Plugin (BuilderCodegen)**:
>   - Add Maven parameter `graphql-dgs-codegen-core.version` and log selected version.
>   - Build versioned GitHub URL (`v<version>`) for `CodeGen.kt` via new `buildCodeGenConfigUrl` and use it in `execute()`.
> - **Tests**:
>   - Update `testDownloadCodeGenConfig` to use a versioned `v8.1.1` URL instead of `master`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 405c639572676fa3103c8263ab697a046087a9ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->