### PR TITLE
Dgs codegen dependency update

### DIFF
--- a/graphqlcodegen-bootstrap-plugin/src/main/java/io/github/deweyjose/bootstrapcodegen/BuilderCodegen.java
+++ b/graphqlcodegen-bootstrap-plugin/src/main/java/io/github/deweyjose/bootstrapcodegen/BuilderCodegen.java
@@ -62,7 +62,7 @@ public class BuilderCodegen extends AbstractMojo {
   /**
    * Build the GitHub URL for CodeGen.kt based on the version.
    *
-   * @param version The version of graphql-dgs-codegen-core (e.g., "8.2.1").
+   * @param version The version of graphql-dgs-codegen-core (e.g., "8.2.3").
    * @return The GitHub raw URL pointing to the versioned CodeGen.kt file.
    */
   private String buildCodeGenConfigUrl(String version) {

--- a/graphqlcodegen-bootstrap-plugin/src/test/java/io/github/deweyjose/bootstrapcodegen/BuilderCodegenTest.java
+++ b/graphqlcodegen-bootstrap-plugin/src/test/java/io/github/deweyjose/bootstrapcodegen/BuilderCodegenTest.java
@@ -11,9 +11,9 @@ class BuilderCodegenTest {
 
   @Test
   void testDownloadCodeGenConfig() throws Exception {
-    // Use a versioned URL (v8.2.1) instead of master branch
+    // Use a versioned URL (v8.2.3) instead of master branch
     String url =
-        "https://raw.githubusercontent.com/Netflix/dgs-codegen/v8.2.1/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt";
+        "https://raw.githubusercontent.com/Netflix/dgs-codegen/v8.2.3/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt";
     String codeGenConfig = BuilderCodegen.downloadCodeGenConfig(url);
     assertNotNull(codeGenConfig, "CodeGenConfig should not be null");
     assertTrue(

--- a/graphqlcodegen-maven-plugin/pom.xml
+++ b/graphqlcodegen-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <artifactId>graphqlcodegen-maven-plugin</artifactId>
-  <version>3.6.0</version>
+  <version>3.6.1</version>
   <packaging>maven-plugin</packaging>
 
   <name>GraphQL Code Generator Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
-    <graphql-dgs-codegen-core.version>8.2.1</graphql-dgs-codegen-core.version>
+    <graphql-dgs-codegen-core.version>8.2.3</graphql-dgs-codegen-core.version>
     <java.version>17</java.version>
     <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
     <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>


### PR DESCRIPTION
Update `dgs-codegen` library dependency to 8.2.3 and increment the plugin semver to 3.6.1.

---
<a href="https://cursor.com/background-agent?bcId=bc-0cd7fd51-64f7-4795-8d51-170495855063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0cd7fd51-64f7-4795-8d51-170495855063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates dependency and plugin versions to align with DGS Codegen 8.2.3.
> 
> - Bumps `graphql-dgs-codegen-core` to `8.2.3` in root `pom.xml`; adjusts `BuilderCodegen` Javadoc and test URLs to use tag `v8.2.3`
> - Increments `graphqlcodegen-maven-plugin` version to `3.6.1` in its `pom.xml`
> - No functional code changes beyond version strings
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e7ca26d53b1a9f117073e232ba723faac69a145. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->