### PR TITLE
Dgs codegen dependency update

### DIFF
--- a/graphqlcodegen-bootstrap-plugin/src/main/java/io/github/deweyjose/bootstrapcodegen/BuilderCodegen.java
+++ b/graphqlcodegen-bootstrap-plugin/src/main/java/io/github/deweyjose/bootstrapcodegen/BuilderCodegen.java
@@ -62,7 +62,7 @@ public class BuilderCodegen extends AbstractMojo {
   /**
    * Build the GitHub URL for CodeGen.kt based on the version.
    *
-   * @param version The version of graphql-dgs-codegen-core (e.g., "8.2.3").
+   * @param version The version of graphql-dgs-codegen-core (e.g., "8.3.0").
    * @return The GitHub raw URL pointing to the versioned CodeGen.kt file.
    */
   private String buildCodeGenConfigUrl(String version) {

--- a/graphqlcodegen-bootstrap-plugin/src/test/java/io/github/deweyjose/bootstrapcodegen/BuilderCodegenTest.java
+++ b/graphqlcodegen-bootstrap-plugin/src/test/java/io/github/deweyjose/bootstrapcodegen/BuilderCodegenTest.java
@@ -11,9 +11,9 @@ class BuilderCodegenTest {
 
   @Test
   void testDownloadCodeGenConfig() throws Exception {
-    // Use a versioned URL (v8.2.3) instead of master branch
+    // Use a versioned URL (v8.3.0) instead of master branch
     String url =
-        "https://raw.githubusercontent.com/Netflix/dgs-codegen/v8.2.3/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt";
+        "https://raw.githubusercontent.com/Netflix/dgs-codegen/v8.3.0/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt";
     String codeGenConfig = BuilderCodegen.downloadCodeGenConfig(url);
     assertNotNull(codeGenConfig, "CodeGenConfig should not be null");
     assertTrue(

--- a/graphqlcodegen-maven-plugin/pom.xml
+++ b/graphqlcodegen-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <artifactId>graphqlcodegen-maven-plugin</artifactId>
-  <version>3.6.1</version>
+  <version>3.7.0</version>
   <packaging>maven-plugin</packaging>
 
   <name>GraphQL Code Generator Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
-    <graphql-dgs-codegen-core.version>8.2.3</graphql-dgs-codegen-core.version>
+    <graphql-dgs-codegen-core.version>8.3.0</graphql-dgs-codegen-core.version>
     <java.version>17</java.version>
     <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
     <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>


### PR DESCRIPTION
Update DGS Codegen dependency to 8.3.0 and bump the plugin's semver to 3.7.0.

The update includes bumping the core `graphql-dgs-codegen-core` version, incrementing the plugin's own version, and updating hardcoded version references in tests and Javadoc for consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-f10c12d2-2666-463c-8454-b6bf4ae5d844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f10c12d2-2666-463c-8454-b6bf4ae5d844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Upgrade versions and align references**
> 
> - Bumps root `graphql-dgs-codegen-core` property to `8.3.0`; updates test URL and Javadoc references to the same version
> - Increments `graphqlcodegen-maven-plugin` artifact version from `3.6.1` to `3.7.0`
> - No functional code changes beyond version string updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae6a0fbfa8473130a079e764edbb3807cfa8a0e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->