### PR TITLE
fix(introspection): schema transformation for custom scalar

### DIFF
--- a/src/main/java/io/github/deweyjose/graphqlcodegen/services/SchemaTransformationService.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/services/SchemaTransformationService.java
@@ -1,7 +1,11 @@
 package io.github.deweyjose.graphqlcodegen.services;
 
 import graphql.language.*;
+import graphql.schema.Coercing;
+import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
+import graphql.schema.TypeResolver;
 import graphql.schema.idl.*;
 import io.github.deweyjose.graphqlcodegen.Logger;
 import java.nio.file.Files;
@@ -14,6 +18,27 @@ public class SchemaTransformationService {
   private static final String QUERY = "Query";
   private static final String MUTATION = "Mutation";
   private static final String SUBSCRIPTION = "Subscription";
+  private static final DataFetcher<Object> NO_OP_DATA_FETCHER = environment -> null;
+  private static final TypeResolver NO_OP_TYPE_RESOLVER = environment -> null;
+  private static final Coercing<Object, Object> PASS_THROUGH_COERCING =
+      new Coercing<>() {
+        @Override
+        public Object serialize(Object dataFetcherResult) {
+          return dataFetcherResult;
+        }
+
+        @Override
+        public Object parseValue(Object input) {
+          return input;
+        }
+
+        @Override
+        public Object parseLiteral(Object input) {
+          return input;
+        }
+      };
+  private static final RuntimeWiring SCHEMA_PRINTING_WIRING =
+      RuntimeWiring.newRuntimeWiring().wiringFactory(new SchemaPrintingWiringFactory()).build();
 
   /**
    * Transforms GraphQL schema content by normalizing root operation type names.
@@ -134,8 +159,52 @@ public class SchemaTransformationService {
 
   private String printSchema(TypeDefinitionRegistry registry) {
     GraphQLSchema schema =
-        new SchemaGenerator()
-            .makeExecutableSchema(registry, RuntimeWiring.newRuntimeWiring().build());
+        new SchemaGenerator().makeExecutableSchema(registry, SCHEMA_PRINTING_WIRING);
     return new SchemaPrinter().print(schema);
+  }
+
+  private static final class SchemaPrintingWiringFactory implements WiringFactory {
+    @Override
+    public boolean providesTypeResolver(InterfaceWiringEnvironment environment) {
+      return true;
+    }
+
+    @Override
+    public TypeResolver getTypeResolver(InterfaceWiringEnvironment environment) {
+      return NO_OP_TYPE_RESOLVER;
+    }
+
+    @Override
+    public boolean providesTypeResolver(UnionWiringEnvironment environment) {
+      return true;
+    }
+
+    @Override
+    public TypeResolver getTypeResolver(UnionWiringEnvironment environment) {
+      return NO_OP_TYPE_RESOLVER;
+    }
+
+    @Override
+    public boolean providesDataFetcher(FieldWiringEnvironment environment) {
+      return true;
+    }
+
+    @Override
+    public DataFetcher<?> getDataFetcher(FieldWiringEnvironment environment) {
+      return NO_OP_DATA_FETCHER;
+    }
+
+    @Override
+    public boolean providesScalar(ScalarWiringEnvironment environment) {
+      return !ScalarInfo.isGraphqlSpecifiedScalar(environment.getScalarTypeDefinition().getName());
+    }
+
+    @Override
+    public GraphQLScalarType getScalar(ScalarWiringEnvironment environment) {
+      return GraphQLScalarType.newScalar()
+          .name(environment.getScalarTypeDefinition().getName())
+          .coercing(PASS_THROUGH_COERCING)
+          .build();
+    }
   }
 }

--- a/src/test/java/io/github/deweyjose/graphqlcodegen/services/SchemaTransformationServiceTest.java
+++ b/src/test/java/io/github/deweyjose/graphqlcodegen/services/SchemaTransformationServiceTest.java
@@ -156,4 +156,68 @@ class SchemaTransformationServiceTest {
     assertTrue(transformed.contains("hello: String"));
     assertTrue(Files.readString(schemaFile).contains("type Query {"));
   }
+
+  @Test
+    void shouldHandleCustomScalarsInIntrospectionStyleSchema() {
+    String schema =
+        """
+            schema {
+                query: query_root
+                mutation: mutation_root
+                subscription: subscription_root
+            }
+
+            scalar uuid
+            scalar timestamptz
+
+            type query_root {
+                pipeline(where: PipelineBoolExp): [Pipeline!]!
+            }
+
+            type mutation_root {
+                insertPipeline(object: PipelineInsertInput!): PipelineMutationResponse!
+            }
+
+            type subscription_root {
+                pipelineStream(where: PipelineBoolExp): [Pipeline!]!
+            }
+
+            type Pipeline {
+                id: uuid!
+                startedAt: timestamptz
+            }
+
+            input PipelineBoolExp {
+                id: UuidComparisonExp
+                startedAt: TimestamptzComparisonExp
+            }
+
+            input UuidComparisonExp {
+                _eq: uuid
+            }
+
+            input TimestamptzComparisonExp {
+                _eq: timestamptz
+            }
+
+            input PipelineInsertInput {
+                id: uuid
+                startedAt: timestamptz
+            }
+
+            type PipelineMutationResponse {
+                returning: [Pipeline!]!
+            }
+            """;
+
+    String transformed = assertDoesNotThrow(() -> service.transformSchema(schema));
+
+    assertTrue(transformed.contains("type Query {"));
+    assertTrue(transformed.contains("type Mutation {"));
+    assertTrue(transformed.contains("type Subscription {"));
+    assertTrue(transformed.contains("scalar uuid"));
+    assertTrue(transformed.contains("scalar timestamptz"));
+    assertTrue(transformed.contains("id: uuid!"));
+    assertTrue(transformed.contains("startedAt: timestamptz"));
+  }
 }

--- a/src/test/java/io/github/deweyjose/graphqlcodegen/services/SchemaTransformationServiceTest.java
+++ b/src/test/java/io/github/deweyjose/graphqlcodegen/services/SchemaTransformationServiceTest.java
@@ -158,7 +158,7 @@ class SchemaTransformationServiceTest {
   }
 
   @Test
-    void shouldHandleCustomScalarsInIntrospectionStyleSchema() {
+  void shouldHandleCustomScalarsInIntrospectionStyleSchema() {
     String schema =
         """
             schema {


### PR DESCRIPTION
#312 

SchemaTransformationService` rewrites custom root operation names to the standard `Query`, `Mutation`, and `Subscription` names before printing the schema back to SDL.

This step currently rebuilds an executable `GraphQLSchema` from the parsed registry. That works for simple schemas, but it breaks on introspected schemas when they contain custom scalars such as `uuid` and `timestamptz`.

With an empty `RuntimeWiring`, `graphql-java` cannot build the executable schema and fails before `SchemaPrinter` gets a chance to print the transformed schema.

## What this MR does

This MR replaces the empty runtime wiring with a minimal local wiring dedicated to schema printing:
- no-op data fetchers
- no-op type resolvers
- placeholder scalar implementations for non-standard scalars

This is enough to let `graphql-java` build a printable schema without relying on `RuntimeWiring.MOCKED_WIRING`, which is documented as testing-only.

## Result

The transformation step now works for introspected schemas with custom scalars, while remaining safe because the generated wiring is only used to print the schema, not to execute it.

## Tests

Added a regression test covering a schema with:
- custom root operation names
- custom scalars (`uuid`, `timestamptz`)
- input types referencing those scalars