### PR TITLE
Make plugin thread safe

### DIFF
--- a/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
@@ -22,6 +22,7 @@ import org.apache.maven.project.MavenProject;
 @Getter
 @Mojo(
     name = "generate",
+    threadSafe = true,
     defaultPhase = LifecyclePhase.GENERATE_SOURCES,
     requiresDependencyResolution = ResolutionScope.COMPILE)
 public class Codegen extends AbstractMojo implements CodegenConfigProvider {
@@ -193,21 +194,21 @@ public class Codegen extends AbstractMojo implements CodegenConfigProvider {
 
   @Override
   public void execute() {
-    Logger.registerMavenLog(getLog());
+    Logger logger = new MavenLogger(getLog());
 
     if (skip) {
-      Logger.info("Skipping code generation as requested (skip=true)");
+      logger.info("Skipping code generation as requested (skip=true)");
       return;
     }
 
     SchemaManifestService manifest =
         new SchemaManifestService(schemaManifestOutputDir, project.getBasedir());
     TypeMappingService typeMappingService = new TypeMappingService();
-    SchemaFileService schemaFileService = new SchemaFileService(outputDir, manifest);
+    SchemaFileService schemaFileService = new SchemaFileService(outputDir, manifest, logger);
 
     Set<Artifact> artifacts = project.getArtifacts();
 
-    var executor = new CodegenExecutor(schemaFileService, typeMappingService);
+    var executor = new CodegenExecutor(schemaFileService, typeMappingService, logger);
     executor.execute(this, artifacts, project.getBasedir());
 
     if (autoAddSource) {

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/CodegenExecutor.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/CodegenExecutor.java
@@ -23,6 +23,7 @@ import org.apache.maven.artifact.Artifact;
 public class CodegenExecutor {
   private final SchemaFileService schemaFileService;
   private final TypeMappingService typeMappingService;
+  private final Logger logger;
 
   /**
    * Constructor for CodegenExecutor.
@@ -31,9 +32,10 @@ public class CodegenExecutor {
    * @param typeMappingService the type mapping service
    */
   public CodegenExecutor(
-      SchemaFileService schemaFileService, TypeMappingService typeMappingService) {
+      SchemaFileService schemaFileService, TypeMappingService typeMappingService, Logger logger) {
     this.schemaFileService = schemaFileService;
     this.typeMappingService = typeMappingService;
+    this.logger = logger;
   }
 
   /**
@@ -48,7 +50,7 @@ public class CodegenExecutor {
     // get the schema paths that might have changed or all of them.
     if (request.isOnlyGenerateChanged()) {
       schemaFileService.loadExpandedSchemaPaths(request.getSchemaPaths());
-      Logger.info("expanded schema paths: {}", schemaFileService.getSchemaPaths());
+      logger.info("expanded schema paths: {}", schemaFileService.getSchemaPaths());
     } else {
       schemaFileService.setSchemaPaths(request.getSchemaPaths());
     }
@@ -63,11 +65,11 @@ public class CodegenExecutor {
 
     if (request.isOnlyGenerateChanged()) {
       schemaFileService.filterChangedSchemaFiles();
-      Logger.info("changed schema files: {}", schemaFileService.getSchemaPaths());
+      logger.info("changed schema files: {}", schemaFileService.getSchemaPaths());
     }
 
     if (schemaFileService.noWorkToDo()) {
-      Logger.info("no files to generate");
+      logger.info("no files to generate");
       return;
     }
 
@@ -131,11 +133,11 @@ public class CodegenExecutor {
             .build();
 
     if (request.isOmitNullInputFields()) {
-      Logger.warn(
+      logger.warn(
           "omitNullInputFields is no longer supported by graphql-dgs-codegen-core >= 8.2.1; ignoring.");
     }
 
-    Logger.info("Codegen config: \n{}", config);
+    logger.info("Codegen config: \n{}", config);
     final CodeGen codeGen = new CodeGen(config);
     codeGen.generate();
 

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/Logger.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/Logger.java
@@ -1,23 +1,7 @@
 package io.github.deweyjose.graphqlcodegen;
 
-import org.apache.maven.plugin.logging.Log;
-import org.slf4j.helpers.MessageFormatter;
-
-/** Logger class for logging messages to the Maven logger. */
-public class Logger {
-  private static volatile Log mavenLog;
-
-  /** Private constructor to prevent instantiation. */
-  private Logger() {}
-
-  /**
-   * Registers the Maven logger.
-   *
-   * @param log the Maven logger
-   */
-  public static void registerMavenLog(Log log) {
-    mavenLog = log;
-  }
+/** Logger abstraction. */
+public interface Logger {
 
   /**
    * Logs an info message.
@@ -25,11 +9,7 @@ public class Logger {
    * @param format the format string
    * @param args the arguments
    */
-  public static void info(String format, Object... args) {
-    if (mavenLog != null) {
-      mavenLog.info(MessageFormatter.arrayFormat(format, args).getMessage());
-    }
-  }
+  void info(String format, Object... args);
 
   /**
    * Logs a debug message.
@@ -37,11 +17,7 @@ public class Logger {
    * @param format the format string
    * @param args the arguments
    */
-  public static void debug(String format, Object... args) {
-    if (mavenLog != null) {
-      mavenLog.debug(MessageFormatter.arrayFormat(format, args).getMessage());
-    }
-  }
+  void debug(String format, Object... args);
 
   /**
    * Logs a warning message.
@@ -49,11 +25,7 @@ public class Logger {
    * @param format the format string
    * @param args the arguments
    */
-  public static void warn(String format, Object... args) {
-    if (mavenLog != null) {
-      mavenLog.warn(MessageFormatter.arrayFormat(format, args).getMessage());
-    }
-  }
+  void warn(String format, Object... args);
 
   /**
    * Logs an error message.
@@ -61,9 +33,5 @@ public class Logger {
    * @param format the format string
    * @param args the arguments
    */
-  public static void error(String format, Object... args) {
-    if (mavenLog != null) {
-      mavenLog.error(MessageFormatter.arrayFormat(format, args).getMessage());
-    }
-  }
+  void error(String format, Object... args);
 }

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/MavenLogger.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/MavenLogger.java
@@ -1,0 +1,42 @@
+package io.github.deweyjose.graphqlcodegen;
+
+import java.util.Objects;
+import org.apache.maven.plugin.logging.Log;
+import org.slf4j.helpers.MessageFormatter;
+
+/** Logger class for logging messages to the Maven logger. */
+class MavenLogger implements Logger {
+  private final Log mavenLog;
+
+  MavenLogger(Log log) {
+    mavenLog = Objects.requireNonNull(log);
+  }
+
+  @Override
+  public void info(String format, Object... args) {
+    if (mavenLog.isInfoEnabled()) {
+      mavenLog.info(MessageFormatter.arrayFormat(format, args).getMessage());
+    }
+  }
+
+  @Override
+  public void debug(String format, Object... args) {
+    if (mavenLog.isDebugEnabled()) {
+      mavenLog.debug(MessageFormatter.arrayFormat(format, args).getMessage());
+    }
+  }
+
+  @Override
+  public void warn(String format, Object... args) {
+    if (mavenLog.isWarnEnabled()) {
+      mavenLog.warn(MessageFormatter.arrayFormat(format, args).getMessage());
+    }
+  }
+
+  @Override
+  public void error(String format, Object... args) {
+    if (mavenLog.isErrorEnabled()) {
+      mavenLog.error(MessageFormatter.arrayFormat(format, args).getMessage());
+    }
+  }
+}

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/services/RemoteSchemaService.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/services/RemoteSchemaService.java
@@ -31,6 +31,7 @@ import lombok.SneakyThrows;
 public class RemoteSchemaService {
   private final HttpClient httpClient;
   private final ObjectMapper objectMapper = new ObjectMapper();
+  private final Logger logger;
 
   /**
    * Represents a GraphQL introspection operation, including the query and optional operation name.
@@ -46,7 +47,8 @@ public class RemoteSchemaService {
   }
 
   /** Constructs a new RemoteSchemaService using Java's built-in HttpClient. */
-  public RemoteSchemaService() {
+  public RemoteSchemaService(Logger logger) {
+    this.logger = logger;
     this.httpClient = HttpClient.newHttpClient();
   }
 
@@ -61,7 +63,7 @@ public class RemoteSchemaService {
   public String getRemoteSchemaFile(String url) throws IOException, InterruptedException {
     HttpRequest request = HttpRequest.newBuilder().uri(URI.create(url)).GET().build();
     HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-    Logger.debug("Remote schema file: {}", response.body());
+    logger.debug("Remote schema file: {}", response.body());
     if (response.statusCode() != 200) {
       throw new IOException("Failed to get remote schema file: " + response.statusCode());
     }
@@ -91,7 +93,7 @@ public class RemoteSchemaService {
 
     HttpRequest request = builder.build();
     HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-    Logger.debug("Introspection results: {}", response.body());
+    logger.debug("Introspection results: {}", response.body());
     if (response.statusCode() != 200) {
       throw new IOException("Failed to get introspection results: " + response.statusCode());
     }

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/services/SchemaFileService.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/services/SchemaFileService.java
@@ -1,5 +1,6 @@
 package io.github.deweyjose.graphqlcodegen.services;
 
+import io.github.deweyjose.graphqlcodegen.Logger;
 import io.github.deweyjose.graphqlcodegen.parameters.IntrospectionRequest;
 import io.github.deweyjose.graphqlcodegen.services.RemoteSchemaService.IntrospectionOperation;
 import java.io.File;
@@ -36,9 +37,14 @@ public class SchemaFileService {
    *
    * @param outputDir the output directory to save the schema files
    * @param manifest the manifest service to use
+   * @param logger the maven logger
    */
-  public SchemaFileService(File outputDir, SchemaManifestService manifest) {
-    this(outputDir, manifest, new RemoteSchemaService(), new SchemaTransformationService());
+  public SchemaFileService(File outputDir, SchemaManifestService manifest, Logger logger) {
+    this(
+        outputDir,
+        manifest,
+        new RemoteSchemaService(logger),
+        new SchemaTransformationService(logger));
   }
 
   /**

--- a/src/main/java/io/github/deweyjose/graphqlcodegen/services/SchemaTransformationService.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/services/SchemaTransformationService.java
@@ -11,9 +11,14 @@ import lombok.SneakyThrows;
 
 /** Service for transforming GraphQL schemas. */
 public class SchemaTransformationService {
+  private final Logger logger;
   private static final String QUERY = "Query";
   private static final String MUTATION = "Mutation";
   private static final String SUBSCRIPTION = "Subscription";
+
+  public SchemaTransformationService(Logger logger) {
+    this.logger = logger;
+  }
 
   /**
    * Transforms GraphQL schema content by normalizing root operation type names.
@@ -27,7 +32,7 @@ public class SchemaTransformationService {
     Optional<SchemaDefinition> schemaDefOpt = registry.schemaDefinition();
 
     if (schemaDefOpt.isEmpty()) {
-      Logger.debug("No schema definition found, skipping transformation");
+      logger.debug("No schema definition found, skipping transformation");
       return schemaContent;
     }
 
@@ -35,7 +40,7 @@ public class SchemaTransformationService {
     Map<String, String> typeMappings = extractRootTypeMappings(schemaDef);
 
     if (typeMappings.isEmpty()) {
-      Logger.debug("No custom root types found, skipping transformation");
+      logger.debug("No custom root types found, skipping transformation");
       return schemaContent;
     }
 
@@ -58,8 +63,8 @@ public class SchemaTransformationService {
   public String transformSchemaFile(Path schemaFile) {
     String content = Files.readString(schemaFile);
     String transformed = transformSchema(content);
-    Logger.debug("Original schema: {}", content);
-    Logger.debug("Transformed schema: {}", transformed);
+    logger.debug("Original schema: {}", content);
+    logger.debug("Transformed schema: {}", transformed);
     if (!content.equals(transformed)) {
       Files.writeString(schemaFile, transformed);
     }

--- a/src/test/java/io/github/deweyjose/graphqlcodegen/CodegenExecutorTest.java
+++ b/src/test/java/io/github/deweyjose/graphqlcodegen/CodegenExecutorTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 class CodegenExecutorTest {
 
   private RemoteSchemaService remoteSchemaService;
+  private Logger logger;
   private SchemaTransformationService schemaTransformationService;
   private SchemaFileService schemaFileService;
   private TypeMappingService typeMappingService;
@@ -35,7 +36,8 @@ class CodegenExecutorTest {
   @BeforeEach
   void setUp() {
     remoteSchemaService = mock(RemoteSchemaService.class);
-    schemaTransformationService = new SchemaTransformationService();
+    logger = new Slf4jLogger();
+    schemaTransformationService = new SchemaTransformationService(logger);
     typeMappingService = new TypeMappingService();
 
     // Setup single output directory
@@ -55,7 +57,7 @@ class CodegenExecutorTest {
     schemaFileService =
         new SchemaFileService(
             outputDir, manifestService, remoteSchemaService, schemaTransformationService);
-    executor = new CodegenExecutor(schemaFileService, typeMappingService);
+    executor = new CodegenExecutor(schemaFileService, typeMappingService, logger);
 
     TestCodegenProvider config = new TestCodegenProvider();
     config.setSchemaPaths(Set.of(schemaFile));
@@ -84,7 +86,7 @@ class CodegenExecutorTest {
     schemaFileService =
         new SchemaFileService(
             outputDir, manifestService, remoteSchemaService, schemaTransformationService);
-    executor = new CodegenExecutor(schemaFileService, typeMappingService);
+    executor = new CodegenExecutor(schemaFileService, typeMappingService, logger);
 
     TestCodegenProvider config = new TestCodegenProvider();
     config.setOutputDir(outputDir);
@@ -118,7 +120,7 @@ class CodegenExecutorTest {
     schemaFileService =
         new SchemaFileService(
             outputDir, manifestService, remoteSchemaService, schemaTransformationService);
-    executor = new CodegenExecutor(schemaFileService, typeMappingService);
+    executor = new CodegenExecutor(schemaFileService, typeMappingService, logger);
 
     TestCodegenProvider config = new TestCodegenProvider();
     config.setSchemaPaths(Set.of(schemaFile));
@@ -155,7 +157,7 @@ class CodegenExecutorTest {
     schemaFileService =
         new SchemaFileService(
             outputDir, manifestService, remoteSchemaService, schemaTransformationService);
-    executor = new CodegenExecutor(schemaFileService, typeMappingService);
+    executor = new CodegenExecutor(schemaFileService, typeMappingService, logger);
 
     TestCodegenProvider config = new TestCodegenProvider();
     config.setSchemaPaths(Set.of(schemaFile));
@@ -211,7 +213,7 @@ class CodegenExecutorTest {
     schemaFileService =
         new SchemaFileService(
             outputDir, manifestService, remoteSchemaService, schemaTransformationService);
-    executor = new CodegenExecutor(schemaFileService, typeMappingService);
+    executor = new CodegenExecutor(schemaFileService, typeMappingService, logger);
 
     executor.execute(config, new HashSet<>(), new File("."));
 
@@ -253,7 +255,7 @@ class CodegenExecutorTest {
     schemaFileService =
         new SchemaFileService(
             outputDir, manifestService, remoteSchemaService, schemaTransformationService);
-    executor = new CodegenExecutor(schemaFileService, typeMappingService);
+    executor = new CodegenExecutor(schemaFileService, typeMappingService, logger);
 
     executor.execute(config, new HashSet<>(), new File("."));
 

--- a/src/test/java/io/github/deweyjose/graphqlcodegen/Slf4jLogger.java
+++ b/src/test/java/io/github/deweyjose/graphqlcodegen/Slf4jLogger.java
@@ -1,0 +1,36 @@
+package io.github.deweyjose.graphqlcodegen;
+
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.helpers.MessageFormatter;
+
+@Slf4j
+public class Slf4jLogger implements Logger {
+
+  @Override
+  public void info(String format, Object... args) {
+    if (log.isInfoEnabled()) {
+      log.info(MessageFormatter.arrayFormat(format, args).getMessage());
+    }
+  }
+
+  @Override
+  public void debug(String format, Object... args) {
+    if (log.isDebugEnabled()) {
+      log.debug(MessageFormatter.arrayFormat(format, args).getMessage());
+    }
+  }
+
+  @Override
+  public void warn(String format, Object... args) {
+    if (log.isWarnEnabled()) {
+      log.warn(MessageFormatter.arrayFormat(format, args).getMessage());
+    }
+  }
+
+  @Override
+  public void error(String format, Object... args) {
+    if (log.isErrorEnabled()) {
+      log.error(MessageFormatter.arrayFormat(format, args).getMessage());
+    }
+  }
+}

--- a/src/test/java/io/github/deweyjose/graphqlcodegen/services/RemoteSchemaServiceTest.java
+++ b/src/test/java/io/github/deweyjose/graphqlcodegen/services/RemoteSchemaServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+import io.github.deweyjose.graphqlcodegen.Slf4jLogger;
 import io.github.deweyjose.graphqlcodegen.TestUtils;
 import io.github.deweyjose.graphqlcodegen.services.RemoteSchemaService.IntrospectionOperation;
 import java.io.IOException;
@@ -16,9 +17,11 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class RemoteSchemaServiceTest {
+  private Slf4jLogger logger;
   private static HttpServer server;
   private static String baseUrl;
   private static final String GET_RESPONSE = "schema { query: Query }";
@@ -76,16 +79,21 @@ class RemoteSchemaServiceTest {
     server.stop(0);
   }
 
+  @BeforeEach
+  void setUp() {
+    logger = new Slf4jLogger();
+  }
+
   @Test
   void testGetRemoteSchemaFile_success() throws Exception {
-    RemoteSchemaService service = new RemoteSchemaService();
+    RemoteSchemaService service = new RemoteSchemaService(logger);
     String result = service.getRemoteSchemaFile(baseUrl + "/schema");
     assertEquals(GET_RESPONSE, result);
   }
 
   @Test
   void testGetIntrospectionResults_success() throws Exception {
-    RemoteSchemaService service = new RemoteSchemaService();
+    RemoteSchemaService service = new RemoteSchemaService(logger);
     String query = INTROSPECTION_QUERY;
     Map<String, String> headers = new HashMap<>();
     headers.put("X-Test-Header", "test");
@@ -110,7 +118,7 @@ class RemoteSchemaServiceTest {
 
   @Test
   void testGetRemoteSchemaFile_notFound() {
-    RemoteSchemaService service = new RemoteSchemaService();
+    RemoteSchemaService service = new RemoteSchemaService(logger);
     Exception ex =
         assertThrows(
             IOException.class,
@@ -143,7 +151,7 @@ class RemoteSchemaServiceTest {
     String url = "http://localhost:" + port + "/graphql";
     Map<String, String> headers = Map.of("X-Custom-Header", "expected-value");
 
-    RemoteSchemaService service = new RemoteSchemaService();
+    RemoteSchemaService service = new RemoteSchemaService(logger);
     String query = INTROSPECTION_QUERY;
     IntrospectionOperation operation =
         IntrospectionOperation.builder().query(query).operationName("IntrospectionQuery").build();

--- a/src/test/java/io/github/deweyjose/graphqlcodegen/services/SchemaTransformationServiceTest.java
+++ b/src/test/java/io/github/deweyjose/graphqlcodegen/services/SchemaTransformationServiceTest.java
@@ -2,6 +2,7 @@ package io.github.deweyjose.graphqlcodegen.services;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import io.github.deweyjose.graphqlcodegen.Slf4jLogger;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -10,7 +11,8 @@ import org.junit.jupiter.api.io.TempDir;
 
 class SchemaTransformationServiceTest {
 
-  private final SchemaTransformationService service = new SchemaTransformationService();
+  private final SchemaTransformationService service =
+      new SchemaTransformationService(new Slf4jLogger());
 
   @Test
   void shouldTransformCustomRootTypes() {


### PR DESCRIPTION
We are using [Maven parallel builds](https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3) unfortunately we are getting warning that the graphqlcodegen is not thread safe.

We did a quick comparison with the [checklist](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=18153538#ParallelbuildsinMaven3-Mojothreadsafetyassertionchecklist) and one specific issue showed up

> Check all static fields/variables in plugin/plugin code are not subject to threading problems.

`Logger#mavenLog` is currently a mutable static field, multiple Mojo instances may set it to conflicting values. There are multiple ways of solving this, we decided to introduce an abstraction that uses the Maven logger in the plugin and SLF4J in tests. We also took the liberty of introducing log level checks.