### PR TITLE
Replace getType with getTypeOrNull

### DIFF
--- a/src/main/java/io/github/deweyjose/graphqlcodegen/services/SchemaTransformationService.java
+++ b/src/main/java/io/github/deweyjose/graphqlcodegen/services/SchemaTransformationService.java
@@ -94,15 +94,11 @@ public class SchemaTransformationService {
    */
   private void renameTypeAndExtensions(
       TypeDefinitionRegistry registry, String oldName, String newName) {
-    registry
-        .getType(oldName)
-        .ifPresent(
-            type -> {
-              if (type instanceof ObjectTypeDefinition objType) {
-                registry.remove(type);
-                registry.add(objType.transform(builder -> builder.name(newName)));
-              }
-            });
+    TypeDefinition<?> type = registry.getTypeOrNull(oldName);
+    if (type instanceof ObjectTypeDefinition objType) {
+      registry.remove(type);
+      registry.add(objType.transform(builder -> builder.name(newName)));
+    }
 
     List<ObjectTypeExtensionDefinition> extensions =
         new ArrayList<>(registry.objectTypeExtensions().getOrDefault(oldName, List.of()));


### PR DESCRIPTION
`TypeDefinitionRegistry#getType(String)` is deprecated with

> use the {@link #getTypeOrNull(Type)} variants instead since they avoid the allocation of an optional object

We could in theory use

```java
registry.getTypeOrNull(oldName, ObjectTypeDefinition.class);
```

Unfortunately `TypeDefinitionRegistry#getTypeOrNull` has the following line
 
    type.getClass().equals(ofType)

Which would miss `ObjectTypeExtensionDefinition`.