### PR TITLE
Upgrade: graphql-dgs-codegen-core 8.3.0 -> 8.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,11 @@ Example
 
 ## generateClientApiv2
 
+> **Deprecated / no-op since graphql-dgs-codegen-core 8.4.0.** Upstream removed the
+> `generateClientApiv2` option (the v2 client API path was consolidated). The parameter is still
+> accepted so existing POMs keep parsing, but it no longer has any effect. Use `generateClientApi`
+> instead.
+
 - Type: boolean
 - Required: false
 - Default: false
@@ -819,6 +824,23 @@ Example
 ```xml
 
 <disableDatesInGeneratedAnnotation>true</disableDatesInGeneratedAnnotation>
+```
+
+## generatedAnnotationType
+
+Fully-qualified class name of the `@Generated` annotation to apply to generated types. When unset,
+graphql-dgs-codegen-core uses its default (`<packageName>.Generated`). Added in
+graphql-dgs-codegen-core 8.5.0.
+
+- Type: string
+- Required: false
+- Default: (unset)
+
+Example
+
+```xml
+
+<generatedAnnotationType>javax.annotation.processing.Generated</generatedAnnotationType>
 ```
 
 ## introspectionRequests

--- a/graphqlcodegen-maven-plugin/pom.xml
+++ b/graphqlcodegen-maven-plugin/pom.xml
@@ -38,7 +38,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
-    <graphql-dgs-codegen-core.version>8.3.0</graphql-dgs-codegen-core.version>
+    <graphql-dgs-codegen-core.version>8.5.0</graphql-dgs-codegen-core.version>
     <java.version>17</java.version>
     <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
     <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>

--- a/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/CodeGenConfigBuilder.java
+++ b/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/CodeGenConfigBuilder.java
@@ -40,7 +40,11 @@ public class CodeGenConfigBuilder {
 
   private boolean generateClientApi;
 
-  private boolean generateClientApiv2;
+  /**
+   * No longer forwarded to {@link CodeGenConfig}: graphql-dgs-codegen-core removed the {@code
+   * generateClientApiv2} option in 8.4.0. Retained only for source compatibility.
+   */
+  @Deprecated private boolean generateClientApiv2;
 
   private boolean generateInterfaces;
 
@@ -89,6 +93,8 @@ public class CodeGenConfigBuilder {
   private boolean addGeneratedAnnotation;
 
   private boolean disableDatesInGeneratedAnnotation;
+
+  private String generatedAnnotationType;
 
   private boolean addDeprecatedAnnotation;
 
@@ -173,6 +179,7 @@ public class CodeGenConfigBuilder {
     return this;
   }
 
+  @Deprecated
   public CodeGenConfigBuilder setGenerateClientApiv2(boolean generateClientApiv2) {
     this.generateClientApiv2 = generateClientApiv2;
     return this;
@@ -304,6 +311,11 @@ public class CodeGenConfigBuilder {
     return this;
   }
 
+  public CodeGenConfigBuilder setGeneratedAnnotationType(String generatedAnnotationType) {
+    this.generatedAnnotationType = generatedAnnotationType;
+    return this;
+  }
+
   public CodeGenConfigBuilder setAddDeprecatedAnnotation(boolean addDeprecatedAnnotation) {
     this.addDeprecatedAnnotation = addDeprecatedAnnotation;
     return this;
@@ -336,7 +348,6 @@ public class CodeGenConfigBuilder {
         generateBoxedTypes,
         generateIsGetterForPrimitiveBooleanFields,
         generateClientApi,
-        generateClientApiv2,
         generateInterfaces,
         generateKotlinNullableClasses,
         generateKotlinClosureProjections,
@@ -361,6 +372,7 @@ public class CodeGenConfigBuilder {
         implementSerializable,
         addGeneratedAnnotation,
         disableDatesInGeneratedAnnotation,
+        generatedAnnotationType,
         addDeprecatedAnnotation,
         trackInputFieldSet,
         generateJSpecifyAnnotations);

--- a/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
+++ b/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
@@ -186,6 +186,9 @@ public class Codegen extends AbstractMojo implements CodegenConfigProvider {
   @Parameter(property = "disableDatesInGeneratedAnnotation", defaultValue = "false")
   private boolean disableDatesInGeneratedAnnotation;
 
+  @Parameter(property = "generatedAnnotationType")
+  private String generatedAnnotationType;
+
   @Parameter(property = "autoAddSource", defaultValue = "true")
   private boolean autoAddSource;
 

--- a/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/CodegenConfigProvider.java
+++ b/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/CodegenConfigProvider.java
@@ -255,6 +255,12 @@ public interface CodegenConfigProvider {
   boolean isDisableDatesInGeneratedAnnotation();
 
   /**
+   * @return fully-qualified class name of the @Generated annotation to apply to generated types, or
+   *     null to use the codegen default ({@code <packageName>.Generated})
+   */
+  String getGeneratedAnnotationType();
+
+  /**
    * @return remote schema URLs
    */
   List<String> getSchemaUrls();

--- a/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/CodegenExecutor.java
+++ b/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/CodegenExecutor.java
@@ -127,6 +127,7 @@ public class CodegenExecutor {
             .setImplementSerializable(request.isImplementSerializable())
             .setAddGeneratedAnnotation(request.isAddGeneratedAnnotation())
             .setDisableDatesInGeneratedAnnotation(request.isDisableDatesInGeneratedAnnotation())
+            .setGeneratedAnnotationType(request.getGeneratedAnnotationType())
             .setAddDeprecatedAnnotation(request.isAddDeprecatedAnnotation())
             .setTrackInputFieldSet(request.isTrackInputFieldSet())
             .setGenerateJSpecifyAnnotations(request.isGenerateJSpecifyAnnotations())

--- a/graphqlcodegen-maven-plugin/src/test/java/io/github/deweyjose/graphqlcodegen/TestCodegenProvider.java
+++ b/graphqlcodegen-maven-plugin/src/test/java/io/github/deweyjose/graphqlcodegen/TestCodegenProvider.java
@@ -60,6 +60,7 @@ public class TestCodegenProvider implements CodegenConfigProvider {
   private Map<String, ParameterMap> includeEnumImports = new HashMap<>();
   private Map<String, ParameterMap> includeClassImports = new HashMap<>();
   private boolean disableDatesInGeneratedAnnotation = false;
+  private String generatedAnnotationType = null;
   private List<String> schemaUrls = Collections.emptyList();
   private boolean autoAddSource = true;
   private List<IntrospectionRequest> introspectionRequests = Collections.emptyList();
@@ -343,6 +344,11 @@ public class TestCodegenProvider implements CodegenConfigProvider {
   @Override
   public boolean isDisableDatesInGeneratedAnnotation() {
     return disableDatesInGeneratedAnnotation;
+  }
+
+  @Override
+  public String getGeneratedAnnotationType() {
+    return generatedAnnotationType;
   }
 
   @Override


### PR DESCRIPTION
**DRAFT — breaking change. Do not merge or mark ready until a human applies `breaking-change-acknowledged` (or comments `/ack-breaking`).**

Closes #326 (analysis & full constructor diff there).

Bumps `graphql-dgs-codegen-core` `8.3.0 → 8.5.0` and updates the positional `CodeGenConfig` constructor call plus new-option wiring to match.

## What changed

- **pom.xml** — `graphql-dgs-codegen-core.version` → `8.5.0`.
- **`generateClientApiv2` removed upstream (8.4.0)** — dropped from `CodeGenConfigBuilder.build()` positional constructor call (required to compile). The `@Parameter`, provider getter, executor forward, and builder setter are **retained as `@Deprecated` no-ops** so existing POMs keep parsing; README flags it as deprecated/no-op.
- **`generatedAnnotationType` added upstream (8.5.0)** — wired through all 5 layers (Mojo `@Parameter`, provider getter, executor forward, builder field/setter/constructor arg, test provider) + README section. Unset ⇒ `null` ⇒ upstream default `<packageName>.Generated`.
- **Upstream default flips not adopted** — `addGeneratedAnnotation` / `disableDatesInGeneratedAnnotation` now default to `true` upstream, but the plugin keeps its own `@Parameter` defaults (`false`) and forwards them explicitly, so generated output is unchanged for existing consumers.

## Build

**Full reactor `./mvnw -B -ntp install` → BUILD SUCCESS** (all 7 modules), 0 failures, 0 errors:

| Module | Result |
|---|---|
| graphqlcodegen-maven-plugin | 54 tests (2 skipped) |
| common (generates types from schema) | compiles |
| server (`ShowsDatafetcherTest`) | 2 tests |
| client (generates client API) | compiles |
| client-introspection (boot → introspect → generate) | compiles |

The example modules generate code from real schemas via the freshly-built plugin against 8.5.0, then compile/test against it — so generated output still compiles end-to-end.

**Caveat:** this confirms no compile/test breakage but does **not** diff generated sources byte-for-byte vs. 8.3.0. 8.4.1 shape changes that still compile (e.g. `__typename` on projection interfaces, JSpecify required-fields constructors, Kotlin `@JsonCreator` removal) would not fail this build but would alter consumer output — still worth an eyeball diff before release.

## Why this is a draft (breaking per gate)

- (e) generation-path dependency bump (DGS core) — breaking by rule.
- (a)/(c) `generateClientApiv2` is now a behavioral no-op; 8.4.1 upstream changes can alter generated output.

See #326 for the full breaking-change assessment.

## Remaining manual work

- [ ] **Decide `generateClientApiv2` fate** — keep as documented no-op (this PR) or remove the `@Parameter` outright (harder break).
- [ ] **Eyeball-diff generated sources** vs. 8.3.0 to confirm 8.4.1's shape changes are acceptable (the reactor build passes but does not diff output).
- [ ] **Decide on adopting the new upstream annotation defaults** (would mean flipping the plugin's `@Parameter` defaults — itself a breaking change).
- [ ] Human applies `breaking-change-acknowledged` / `/ack-breaking` before this is marked ready.
- [ ] Separately: kotlinpoet 1.18.1→2.3.0 (#320) and graphql-java 25→26 are each independently breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018D1uGMmVEvgAtgpvfkS9xK