### PR TITLE
Reorganize documentation and add module-level AGENTS.md files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,17 @@
 Guidance for AI agents making changes in this repository. Read this before editing — it
 encodes the architecture, the conventions CI enforces, and the gotchas that are easy to miss.
 
+## Doc map
+
+- **This file** — repo-wide: reactor layout, build/test commands, CI, release.
+- [`graphqlcodegen-maven-plugin/AGENTS.md`](graphqlcodegen-maven-plugin/AGENTS.md) — the plugin's
+  code: request flow, services, the option-wiring checklist, module-level gotchas.
+- [`examples/graphqlcodegen-example/AGENTS.md`](examples/graphqlcodegen-example/AGENTS.md) — the
+  vendored example harness: what each module demonstrates, how to extend it.
+- [`README.md`](README.md) — the **consumer-facing option reference**. Its documented types and
+  defaults must match the `@Parameter` declarations in `Codegen.java`; keep it in sync whenever
+  options change.
+
 ## What this project is
 
 A **Maven plugin** (`io.github.deweyjose:graphqlcodegen-maven-plugin`) that wraps Netflix
@@ -55,43 +66,25 @@ tests) *and* `spotless:apply` has been run (otherwise `spotless:check` fails CI)
 reformats aggressively, including test code — formatting-only diffs after edits are normal, so apply
 and re-stage.
 
-## Architecture — request flow
+## Architecture — request flow (summary)
 
 The Mojo collects config, hands it to an executor, which builds a DGS config and runs codegen:
 
 1. **`Codegen.java`** — the `@Mojo`. Every user-facing option is an `@Parameter` field here
    (~50 of them). Implements `CodegenConfigProvider` (it *is* the request object).
-2. **`CodegenConfigProvider.java`** — interface of getters the executor reads. `Codegen` uses
-   Lombok `@Getter` to satisfy it.
-3. **`CodegenExecutor.java`** — `execute(...)` orchestrates: resolves schema files, applies
-   transformations/type mappings, and forwards every option to `CodeGenConfigBuilder`.
+2. **`CodegenConfigProvider.java`** — interface of getters the executor reads.
+3. **`CodegenExecutor.java`** — orchestrates: resolves schema files (local, jar, URL,
+   introspection), applies type mappings, forwards every option to the builder.
 4. **`CodeGenConfigBuilder.java`** — a **checked-in** builder mirroring upstream DGS
-   `CodeGenConfig`. This is the seam between our plugin and DGS. See gotcha below.
-5. **`services/`** — focused helpers, each independently unit-tested:
-   - `SchemaFileService` — expands/resolves schema paths and jar-embedded schemas.
-   - `RemoteSchemaService` — fetches remote schemas, including GraphQL introspection.
-   - `SchemaTransformationService` — normalizes schemas (e.g. root-type renaming, custom scalars).
-   - `SchemaManifestService` — tracks schema hashes for `onlyGenerateChanged` incremental builds.
-   - `TypeMappingService` — merges type-mapping properties (local files + classpath).
-6. **`parameters/`** — structured `@Parameter` value types (`IntrospectionRequest`, `ParameterMap`).
-7. **`Logger` / `MavenLogger`** — logging abstraction so services log without a hard Maven dependency.
+   `CodeGenConfig`. This is the seam between the plugin and DGS.
+5. **`services/`** — focused, independently unit-tested helpers (schema files, remote schemas,
+   transformations, incremental-build manifest, type mappings).
 
-## The most common task: exposing a new DGS codegen option
+Full detail — including **the checklist for exposing a new DGS codegen option** (the most common
+task in this repo) and module-level gotchas — lives in
+[`graphqlcodegen-maven-plugin/AGENTS.md`](graphqlcodegen-maven-plugin/AGENTS.md).
 
-A DGS option existing in upstream `CodeGenConfig` is **not enough** — it must be wired through
-all layers or it is silently unreachable from Maven. To add one:
-
-1. Confirm the option exists in the pinned `graphql-dgs-codegen-core.version` (root `pom.xml`,
-   property `graphql-dgs-codegen-core.version`). Check upstream release notes before bumping —
-   often the fix is wiring, not a version bump.
-2. Add an `@Parameter` field (with default) in **`Codegen.java`**.
-3. Add the getter to **`CodegenConfigProvider.java`**.
-4. Forward it to the builder in **`CodegenExecutor.java`**.
-5. Ensure **`CodeGenConfigBuilder.java`** sets it on the DGS config.
-6. Add/extend tests in `CodegenExecutorTest` and any fixtures under `src/test/resources/schema`.
-7. Document the option in `README.md` (consumers rely on it as the option reference).
-
-## Conventions & gotchas
+## Repo-wide conventions & gotchas
 
 - **`CodeGenConfigBuilder` is checked in.** When bumping `graphql-dgs-codegen-core.version`,
   verify its constructor args and setter surface still match upstream `CodeGenConfig`, then wire
@@ -99,9 +92,12 @@ all layers or it is silently unreachable from Maven. To add one:
 - **Primitive `boolean` options hide gaps.** A missing setter call usually does *not* fail
   compilation because the field defaults to `false`, so a feature can look wired but be inert.
   Add a test that asserts the option actually takes effect.
-- **Mojo is `threadSafe = true`.** Do not introduce shared mutable static state in the request path.
-- **Lombok** is used (`@Getter`, etc.); annotation processing is configured — don't hand-write
-  generated accessors.
+- **Some parameters are intentional no-ops** (`generateClientApiv2`, `omitNullInputFields`,
+  `maxProjectionDepth`) — kept so existing POMs parse after upstream removed the options. Don't
+  wire them up without checking upstream first; don't delete them either.
+- **README is the option reference and it drifts.** When touching any `@Parameter`, cross-check
+  the README section for that option (name, type, default).
+- **Lombok** is used (`@Getter`, etc.); don't hand-write generated accessors.
 - Prefer **name-based test assertions** over hardcoded counts (e.g. assert a fixture name is
   present, not that there are exactly N fixtures) — brittle counts break when fixtures are added.
 
@@ -117,15 +113,15 @@ all layers or it is silently unreachable from Maven. To add one:
   reports **merged** coverage of the plugin's classes: unit tests (`jacoco.exec`) **plus** the
   `Codegen` Mojo executing during the example reactor build (`jacoco-it.exec`, captured by a JaCoCo
   agent on the Maven JVM via `MAVEN_OPTS`). The two are combined with `jacoco:merge@merge-all` +
-  `jacoco:report@report-merged` (executions in the plugin pom). To reproduce locally:
+  `jacoco:report@report-merged` (executions in the plugin pom). Note: `coverage.yml` hardcodes its
+  own JaCoCo agent version — when dependabot bumps `jacoco-maven-plugin` in the plugin pom, check
+  whether the workflow's pinned agent version should follow. To reproduce locally:
   ```bash
   AGENT=$(find ~/.m2 -name 'org.jacoco.agent-*-runtime.jar' | sort | tail -1)
   python3 -m http.server 8000 --directory examples/graphqlcodegen-example/server/src/main/resources/schema &
   MAVEN_OPTS="-javaagent:$AGENT=destfile=$PWD/graphqlcodegen-maven-plugin/target/jacoco-it.exec,append=true,includes=io.github.deweyjose.graphqlcodegen.*" \
     ./mvnw -B -ntp clean install -Dcodegen.server.schemaUrl=http://localhost:8000/main.graphqls
-  ./mvnw -pl graphqlcodegen-maven-plugin \
-    org.jacoco:jacoco-maven-plugin:0.8.14:merge@merge-all \
-    org.jacoco:jacoco-maven-plugin:0.8.14:report@report-merged
+  ./mvnw -pl graphqlcodegen-maven-plugin jacoco:merge@merge-all jacoco:report@report-merged
   # open graphqlcodegen-maven-plugin/target/site/jacoco/index.html
   ```
 - **`E2E Example` (`e2e-example.yaml`) runs on push.** It runs the whole reactor (`./mvnw install`)
@@ -158,14 +154,16 @@ the mocked unit tests cannot, and the `E2E Example` workflow runs exactly this o
   `file:` URL won't work.
 - **Keeping it current:** the files under `examples/graphqlcodegen-example/` are the source of truth.
   Edit them here directly when the plugin gains a feature worth exercising, and keep the example's
-  `graphql-codegen-plugin.version` property in sync with the plugin version.
+  `graphql-codegen-plugin.version` property in sync with the plugin version. See
+  [`examples/graphqlcodegen-example/AGENTS.md`](examples/graphqlcodegen-example/AGENTS.md).
 
 ## Release process
 
 Releasing publishes to **Maven Central** and is **irreversible** — only release green `main`.
 
 1. Bump the version in **both** `graphqlcodegen-maven-plugin/pom.xml` (the published artifact) and
-   the root aggregator `pom.xml` → keep them in sync.
+   the root aggregator `pom.xml` → keep them in sync (and bump the example's
+   `graphql-codegen-plugin.version` property to match).
 2. `./mvnw spotless:apply`, commit, push to `main`, and wait for `main` CI to pass.
 3. Publish a **GitHub Release** with tag `graphqlcodegen-maven-plugin-<version>` targeting `main`.
    The `release: published` event triggers `publish.yaml`, which deploys to Maven Central via

--- a/README.md
+++ b/README.md
@@ -1,903 +1,24 @@
-![code coverage](badges/jacoco.svg)
-
-[View full coverage report](https://deweyjose.github.io/graphqlcodegen/index.html)
-
 # graphqlcodegen-maven-plugin
 
-This maven plugin is a port of the netflix codegen plugin for Gradle.
-Found [here](https://github.com/Netflix/dgs-codegen).
+![code coverage](badges/jacoco.svg) [full coverage report](https://deweyjose.github.io/graphqlcodegen/index.html)
 
-# Architecture
+A Maven plugin for [Netflix DGS codegen](https://github.com/Netflix/dgs-codegen) — a port of the
+official Gradle plugin. It generates Java (or Kotlin) types, example data fetchers, and typed
+client APIs from your GraphQL schema during the build.
 
-This project is a multi-module Maven reactor. The root `pom.xml` is a `pom`-packaging
-aggregator; the published artifact lives in the `graphqlcodegen-maven-plugin` module. The example
-project is vendored in and wired as Maven modules that build **by default**, so a single
-`./mvnw install` runs the plugin's unit tests and the example tests together. Release stays
-plugin-only (scoped with `-pl`), and Spring Boot lives only in the example modules.
+- **Group/artifact:** `io.github.deweyjose:graphqlcodegen-maven-plugin` ([Maven Central](https://central.sonatype.com/artifact/io.github.deweyjose/graphqlcodegen-maven-plugin))
+- **Goal:** `generate` (prefix `graphqlcodegen`), bound to the `generate-sources` phase by default
+- **Requires:** Java 17+
 
-```
-.                                 # aggregator (pom)
-├── graphqlcodegen-maven-plugin/  # the published plugin
-└── examples/graphqlcodegen-example/   # end-to-end harness (built by default)
-    ├── common/  server/  client/  client-introspection/
-```
+## Quick start
 
-## graphqlcodegen-maven-plugin
-This is the Maven plugin that users apply to their projects. It provides goals for generating Java (or Kotlin) code from GraphQL schemas, mirroring the functionality of the Netflix DGS Gradle codegen plugin. It is responsible for:
-- Accepting configuration via plugin parameters.
-- Resolving schema files from the local project and dependencies.
-- Invoking the DGS codegen library with the correct configuration.
-- Managing incremental code generation and manifest tracking.
-- Holding a checked-in `CodeGenConfigBuilder` (`graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen`) that mirrors the upstream `CodeGenConfig` constructor shape.
-
-## examples/graphqlcodegen-example
-A vendored, multi-module DGS project that exercises the plugin end to end: jar-embedded schemas,
-remote/introspection schemas, type mappings, and client-API generation. It builds **by default**
-(plugin first in reactor order, so the examples use the just-built plugin) and is validated on every
-push by the **E2E Example** GitHub Actions workflow. The `client-introspection` module starts its
-own DGS server for live introspection, so no externally-running server is needed. Spring Boot and
-the DGS framework live entirely in these modules and never enter the plugin's own build (a
-`maven-enforcer` rule bans Spring Boot from the plugin). See [Testing with the example
-project](#testing-with-the-example-project).
-
-# Contributing
-
-### GitHub Issue
-
-Feel free to simply create a GitHub issue for requests to integrate with
-newer [releases](https://github.com/Netflix/dgs-codegen/releases) of the core DGS Codegen library.
-
-### PRs
-
-PRs are welcome as well. The level of difficulty across DGS Codegen updates varies. Typically, new plugin options are added when the [CodeGenConfig](https://github.com/Netflix/dgs-codegen/blob/master/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt) constructor in the core library changes.
-
-When constructor parameters change upstream:
-
-- Update `CodeGenConfigBuilder` to match the latest constructor shape and ordering.
-- Wire new options through:
-  - `graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java`
-  - `graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/CodegenConfigProvider.java`
-  - `graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/CodegenExecutor.java`
-- Add/update tests and document options in this README.
-
-Process:
-
-1. Bump the version in both [`graphqlcodegen-maven-plugin/pom.xml`](graphqlcodegen-maven-plugin/pom.xml) and the root aggregator [`pom.xml`](pom.xml), and the example's `graphql-codegen-plugin.version` property (keep them in sync).
-2. Adjust [`Codegen.java`](graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java) and related classes to support new options if needed.
-3. Run `./mvnw spotless:apply install` locally — this builds and tests the plugin **and** the example modules (see below).
-
-## Testing with the example project
-
-The example project lives in `examples/graphqlcodegen-example` and builds **by default** as part of
-the reactor, against the plugin you just built. A single command runs the plugin unit tests and the
-example tests (including the `client-introspection` module, which starts its own DGS server):
-
-```bash
-./mvnw -B -ntp install
-```
-
-`install` (not `verify`) ensures the plugin is installed first so the examples resolve it. The
-`server` module fetches its schema over HTTP from `main` by default; to build fully offline, serve
-the in-repo schema and override the URL:
-
-```bash
-python3 -m http.server 8000 \
-  --directory examples/graphqlcodegen-example/server/src/main/resources/schema &
-./mvnw -B -ntp install -Dcodegen.server.schemaUrl=http://localhost:8000/main.graphqls
-```
-
-The **E2E Example** CI workflow runs exactly this on every push (see
-[`.github/workflows/e2e-example.yaml`](.github/workflows/e2e-example.yaml)).
-
-# Overview
-
-The DGS Code Generation plugin generates code for basic types and example data fetchers based on
-your Domain Graph
-Service's graphql schema file during the project's build process. The plugin requires the
-designated `packageName` for file generation.
-If no `schemaPath` is specified, it will look in the src/main/resources/schema folder for
-any files with .graphqls, .graphql or .gqls extension.
-
-# Example Repo
-
-https://github.com/deweyjose/graphqlcodegen-example
-
-# Options
-
-Options are configured in the `<configuration>` element of the dgs-codegen-maven-plugin plugin.
-
-## onlyGenerateChanged
-
-This options enables the plugin to limit code generation to only schema files that have changed.
-Today this only works with schemaPaths.
-
-This only works for `<schemaPaths>`. A subsequent release for schema compilation via dependencies
-will be release soon.
-
-- Type: boolean
-- Required: false
-- Default: true
+Add the plugin to your pom's `<build><plugins>` section:
 
 ```xml
-
-<onlyGenerateChanged>true</onlyGenerateChanged>
-```
-
-## subPackageNameDocs
-
-- Type: string
-- Required: false
-- Default: docs
-
-Example
-
-```xml
-
-<subPackageNameDocs>docs</subPackageNameDocs>
-```
-
-## generateDocs
-
-- Type: string
-- Required: false
-- Default: docs
-
-Example
-
-```xml
-
-<generateDocs>true</generateDocs>
-```
-
-## generatedDocsFolder
-
-- Type: string
-- Required: false
-- Default: ./generated-docs
-
-Example
-
-```xml
-
-<generatedDocsFolder>true</generatedDocsFolder>
-```
-
-## addGeneratedAnnotation
-
-- Type: boolean
-- Required: false
-- Default: false
-
-Example
-
-```xml
-
-<addGeneratedAnnotation>true</addGeneratedAnnotation>
-```
-
-## skip
-
-- Type: boolean
-- Required: false
-- Default: false
-
-Example
-
-```xml
-
-<dgs.codegen.skip>true</dgs.codegen.skip>
-```
-
-Or
-
-```shell
-# mvn ... -Ddgs.codegen.skip=true
-```
-
-## schemaPaths
-
-A list of schema file or directory paths.
-
-Directory paths: Only files with file extensions `.graphql`, `.graphqls` and `.gqls` will be considered.
-
-Default value is `${project.basedir}/src/main/resources/schema`.
-
-- Type: array
-- Required: false
-- Default: `${project.basedir}/src/main/resources/schema`
-
-Example
-
-```xml
-
-<schemaPaths>
-  <param>src/main/resources/schema/schema.graphqls1</param>
-  <param>src/main/resources/schema/schema.graphqls2</param>
-  <param>src/main/resources/someDirWithSchema</param>
-</schemaPaths>
-```
-
-## schemaJarFilesFromDependencies
-
-- Type: array
-- Required: false
-- Default: []
-- Official
-  doc : https://netflix.github.io/dgs/generating-code-from-schema/#generating-code-from-external-schemas-in-jars.
-- Please note that `.graphql(s)` files must exist under the `META-INF` folder in the external jar
-  file.
-
-Example
-
-```xml
-
-<schemaJarFilesFromDependencies>
-  <param>com.netflix.graphql.dgs:some-dependency:1.0.0</param>
-  <param>com.netflix.graphql.dgs:some-dependency:X.X.X</param>
-</schemaJarFilesFromDependencies>
-```
-
-## packageName
-
-- Type: string
-- Required: true
-
-Example
-
-```xml
-
-<packageName>com.acme.se.generated</packageName>
-```
-
-## typeMapping
-
-- Type: map
-- Required: false
-
-Example
-
-```xml
-
-<typeMapping>
-  <Date>java.time.LocalDateTime</Date>
-</typeMapping>
-```
-
-## `typeMappingPropertiesFiles`
-
-Specifies one or more `typeMapping` properties files that are available as **compile-time classpath resources** from **external dependencies** (e.g., shared JARs).
-
-Each properties file must contain key-value pairs that will be added to the `typeMapping` map **only if a mapping for a given GraphQL type is not already present**.
-
-If the same GraphQL type appears in both the `typeMapping` configuration and one of the `typeMappingPropertiesFiles`, the value from `typeMapping` will take precedence, and the entry from the properties file will be ignored.
-
-- **Type**: Array  
-- **Required**: No
-
-### Example (XML)
-
-```xml
-<typeMappingPropertiesFiles>
-  <typeMappingPropertiesFile>commontypes-typeMapping.properties</typeMappingPropertiesFile>
-  <typeMappingPropertiesFile>someother-commontypes-typeMapping.properties</typeMappingPropertiesFile>
-</typeMappingPropertiesFiles>
-```
-
-## `localTypeMappingPropertiesFiles`
-
-Specifies one or more `typeMapping` properties files that are available in the local project directory. These files should be specified relative to the project root.
-
-Each properties file must contain key-value pairs that will be added to the `typeMapping` map **only if a mapping for a given GraphQL type is not already present**.
-
-If the same GraphQL type appears in both the `typeMapping` configuration and one of the `localTypeMappingPropertiesFiles`, the value from `typeMapping` will take precedence, and the entry from the properties file will be ignored.
-
-- **Type**: Array  
-- **Required**: No
-
-### Example (XML)
-
-```xml
-<localTypeMappingPropertiesFiles>
-  <localTypeMappingPropertiesFile>src/main/resources/type-mapping.properties</localTypeMappingPropertiesFile>
-</localTypeMappingPropertiesFiles>
-```
-
-## subPackageNameClient
-
-- Type: string
-- Required: false
-- Default: client
-
-Example
-
-```xml
-
-<subPackageNameClient>client</subPackageNameClient>
-```
-
-## subPackageNameDatafetchers
-
-- Type: string
-- Required: false
-- Default: client
-
-Example
-
-```xml
-
-<subPackageNameDatafetchers>datafetchers</subPackageNameDatafetchers>
-```
-
-## subPackageNameTypes
-
-- Type: string
-- Required: false
-- Default: client
-
-Example
-
-```xml
-
-<subPackageNameTypes>types</subPackageNameTypes>
-```
-
-## generateBoxedTypes
-
-- Type: boolean
-- Required: false
-- Default: false
-
-Example
-
-```xml
-
-<generateBoxedTypes>false</generateBoxedTypes>
-```
-
-## generateClientApi
-
-- Type: boolean
-- Required: false
-- Default: false
-
-Example
-
-```xml
-
-<generateClientApi>false</generateClientApi>
-```
-
-## generateClientApiv2
-
-> **Deprecated / no-op since graphql-dgs-codegen-core 8.4.0.** Upstream removed the
-> `generateClientApiv2` option (the v2 client API path was consolidated). The parameter is still
-> accepted so existing POMs keep parsing, but it no longer has any effect. Use `generateClientApi`
-> instead.
-
-- Type: boolean
-- Required: false
-- Default: false
-
-Example
-
-```xml
-
-<generateClientApiv2>false</generateClientApiv2>
-```
-
-## generateInterfaces
-
-- Type: boolean
-- Required: false
-- Default: false
-
-Example
-
-```xml
-
-<generateInterfaces>false</generateInterfaces>
-```
-
-## generateKotlinNullableClasses
-
-- Type: boolean
-- Required: false
-- Default: false
-
-Example
-
-```xml
-
-<generateKotlinNullableClasses>false</generateKotlinNullableClasses>
-```
-
-## generateKotlinClosureProjections
-
-- Type: boolean
-- Required: false
-- Default: false
-
-Example
-
-```xml
-
-<generateKotlinClosureProjections>false</generateKotlinClosureProjections>
-```
-
-## outputDir
-
-- Type: string
-- Required: false
-- Default: `${project.build.directory}/generated-sources`
-
-Example:
-
-```xml
-
-<outputDir>${project.build.directory}/generated-sources</outputDir>
-```
-
-## autoAddSource
-
-Controls whether the plugin automatically adds the generated sources directory to the Maven compile classpath. This eliminates the need for the build-helper-maven-plugin in most setups. 
-
-- Type: boolean
-- Required: false
-- Default: true
-
-Example:
-
-```xml
-<autoAddSource>true</autoAddSource>
-```
-
-## exampleOutputDir
-
-- Type: string
-- Required: false
-- Default: `${project.build.directory}/generated-examples`
-
-Example:
-
-```xml
-
-<exampleOutputDir>${project.build.directory}/generated-examples</exampleOutputDir>
-```
-
-## schemaManifestOutputDir
-
-- Type: string
-- Required: false
-- Default: `${project.build.directory}/graphqlcodegen`
-
-Example:
-
-```xml
-
-<schemaManifestOutputDir>${project.build.directory}/graphqlcodegen</schemaManifestOutputDir>
-```
-
-## includeQueries
-
-- Description: Limit generation to specified set of queries. Used in conjunction
-  with `generateClient`.
-- Type: array
-- Required: false
-- Default: []
-
-Example
-
-```xml
-
-<includeQueries>
-  <param>QueryFieldName1</param>
-  <param>QueryFieldName2</param>
-</includeQueries>
-```
-
-## includeMutations
-
-- Description: Limit generation to specified set of mutations. Used in conjunction
-  with `generateClient`.
-- Type: array
-- Required: false
-- Default: []
-
-Example
-
-```xml
-
-<includeMutations>
-  <param>MutationFieldName1</param>
-  <param>MutationFieldName1</param>
-</includeMutations>
-```
-
-## skipEntityQueries
-
-- Type: boolean
-- Required: false
-- Default: false
-
-Example
-
-```xml
-
-<skipEntityQueries>false</skipEntityQueries>
-```
-
-## shortProjectionNames
-
-- Type: boolean
-- Required: false
-- Default: false
-
-Example
-
-```xml
-
-<shortProjectionNames>false</shortProjectionNames>
-```
-
-## generateDataTypes
-
-- Type: boolean
-- Required: false
-- Default: false
-
-Example
-
-```xml
-
-<generateDataTypes>false</generateDataTypes>
-```
-
-## language
-
-- Type: String
-- Required: false
-- Default: java
-
-Example
-
-```xml
-
-<language>kotlin</language>
-```
-
-## omitNullInputFields
-
-- Type: boolean
-- Required: false
-- Default: false
-- Note: ignored with `graphql-dgs-codegen-core` >= 8.2.1 (option removed upstream)
-
-Example
-
-```xml
-
-<omitNullInputFields>false</omitNullInputFields>
-```
-
-## kotlinAllFieldsOptional
-
-- Type: boolean
-- Required: false
-- Default: false
-
-Example
-
-```xml
-
-<kotlinAllFieldsOptional>false</kotlinAllFieldsOptional>
-```
-
-## snakeCaseConstantNames
-
-- Type: boolean
-- Required: false
-- Default: false
-
-Example
-
-```xml
-
-<snakeCaseConstantNames>false</snakeCaseConstantNames>
-```
-
-## writeToFiles
-
-- Type: boolean
-- Required: false
-- Default: true
-
-Example
-
-```xml
-
-<writeToFiles>false</writeToFiles>
-```
-
-## includeSubscriptions
-
-- Type: array
-- Required: false
-- Default: []
-
-Example
-
-```xml
-
-<includeSubscriptions>
-  <param>Subscriptions1</param>
-  <param>Subscriptions2</param>
-</includeSubscriptions>
-```
-
-## generateInterfaceSetters
-
-- Type: boolean
-- Required: false
-- Default: true
-
-Example
-
-```xml
-
-<generateInterfaceSetters>false</generateInterfaceSetters>
-```
-
-## generateInterfaceMethodsForInterfaceFields
-
-- Type: boolean
-- Required: false
-- Default: false
-
-Example
-
-```xml
-
-<generateInterfaceMethodsForInterfaceFields>false</generateInterfaceMethodsForInterfaceFields>
-```
-
-## javaGenerateAllConstructor
-
-- Type: boolean
-- Required: false
-- Default: false
-
-Example
-
-```xml
-
-<javaGenerateAllConstructor>false</javaGenerateAllConstructor>
-```
-
-## implementSerializable
-
-- Type: boolean
-- Required: false
-- Default: false
-
-Example
-
-```xml
-
-<implementSerializable>false</implementSerializable>
-```
-
-## generateCustomAnnotations
-
-- Type: boolean
-- Required: false
-- Default: false
-
-```xml
-
-<generateCustomAnnotations>false</generateCustomAnnotations>
-```
-
-## addDeprecatedAnnotation
-
-- Type: boolean
-- Required: false
-- Default: false
-
-Example
-
-```xml
-
-<addDeprecatedAnnotation>true</addDeprecatedAnnotation>
-```
-
-## trackInputFieldSet
-
-Generate has[FieldName] methods keeping track of what fields are explicitly set on input types. This is useful for distinguishing between fields that were explicitly set to null versus fields that were never set.
-
-- Type: boolean
-- Required: false
-- Default: false
-
-Example
-
-```xml
-<trackInputFieldSet>true</trackInputFieldSet>
-```
-
-## generateJSpecifyAnnotations
-
-Generate [JSpecify](https://jspecify.dev/) null-safety annotations in generated Java code.
-When enabled, generated classes are annotated with `@NullMarked` and nullable members are
-annotated with `@Nullable`.
-
-- Type: boolean
-- Required: false
-- Default: false
-
-Example
-
-```xml
-<generateJSpecifyAnnotations>true</generateJSpecifyAnnotations>
-```
-
-## includeImports
-
-- Type: map<string, string>
-- Required: false
-
-```xml
-
-<includeImports>
-  <validator>com.test.validator</validator>
-</includeImports>
-```
-
-## includeEnumImports
-
-- Type: map<string,<string,string>>
-- Required: false
-
-```xml
-
-<includeEnumImports>
-  <foo>
-    <properties>
-      <bar>bla</bar>
-    </properties>
-  </foo>
-  <bar>
-    <properties>
-      <zoo>bar.bar</zoo>
-      <zing>bla.bla</zing>
-    </properties>
-  </bar>
-</includeEnumImports>
-```
-
-## includeClassImports
-
-Maps the custom annotation and class names to the class packages. Only used when
-generateCustomAnnotations is enabled.
-
-- Type
-- Required: false
-
-```xml
-
-<includeClassImports>
-  <foo>
-    <properties>
-      <bar>bla</bar>
-    </properties>
-  </foo>
-  <bar>
-    <properties>
-      <zoo>bar.bar</zoo>
-
-      <zing>bla.bla</zing>
-    </properties>
-  </bar>
-</includeClassImports>
-```
-
-## generateIsGetterForPrimitiveBooleanFields
-
-- Type: boolean
-- Required: false
-- Default: false
-
-Example
-
-```xml
-
-<generateIsGetterForPrimitiveBooleanFields>false</generateIsGetterForPrimitiveBooleanFields>
-```
-
-## disableDatesInGeneratedAnnotation
-
-- Type: boolean
-- Required: false
-- Default: false
-
-Example
-
-```xml
-
-<disableDatesInGeneratedAnnotation>true</disableDatesInGeneratedAnnotation>
-```
-
-## generatedAnnotationType
-
-Fully-qualified class name of the `@Generated` annotation to apply to generated types. When unset,
-graphql-dgs-codegen-core uses its default (`<packageName>.Generated`). Added in
-graphql-dgs-codegen-core 8.5.0.
-
-- Type: string
-- Required: false
-- Default: (unset)
-
-Example
-
-```xml
-
-<generatedAnnotationType>javax.annotation.processing.Generated</generatedAnnotationType>
-```
-
-## introspectionRequests
-
-> **Experimental:** This is a new feature and may change in future releases.
-
-Allows you to generate code from a GraphQL schema fetched via introspection at build time. You can specify one or more endpoints, queries, operation names, and custom HTTP headers for dynamic schema fetching.
-
-- Type: array of objects (introspectionRequest)
-- Required: false
-- Default: []
-
-Each `introspectionRequest` supports:
-- `url` (string, required): The GraphQL endpoint URL
-- `query` (string, optional): Path to a custom introspection query file (defaults to standard introspection query)
-- `operationName` (string, optional): The operation name for the introspection query
-- `headers` (map<string, string>, optional): HTTP headers to include in the request
-
-Example:
-
-```xml
-<introspectionRequests>
-  <introspectionRequest>
-    <url>https://your-graphql-endpoint/graphql</url>
-    <query>{ __schema { queryType { name } } }</query>
-    <operationName>IntrospectionQuery</operationName>
-    <headers>
-      <Authorization>Bearer ${env.YOUR_TOKEN}</Authorization>
-      <X-Custom-Header>value</X-Custom-Header>
-    </headers>
-  </introspectionRequest>
-</introspectionRequests>
-```
-
-# AI Stories & Project History
-
-Below is a curated set of AI-generated documentation and project history, summarizing key architectural changes, automation, and major improvements. These documents provide context for contributors and maintainers.
-
-| Title | Link | Quick Summary |
-|-------|------|--------------|
-| Automating GraphQL Codegen Maven Plugin Maintenance | [human-thoughts.md](docs/ai-stories/human-thoughts.md) | Reflections on automating plugin maintenance, AI-assisted development, and test coverage improvements. |
-| Multi-Module Refactor & Parameter Plugin Integration | [chat-summary-pr-multimodule-paramplugin.md](docs/ai-stories/chat-summary-pr-multimodule-paramplugin.md) | Details the transition to a multi-module Maven setup and parameter plugin automation. |
-| Major Accomplishments: May 2024 PRs (216, 217, 221, 225, 226, 227, 228) | [chat-summary-major-accomplishments.md](docs/ai-stories/chat-summary-major-accomplishments.md) | Summarizes architectural evolution, automation, and future direction post-major PRs. |
-| PR: Add Code Coverage Reporting, Badge, and GitHub Pages Publishing | [chat-summary-pr-coverage-report-pages.md](docs/ai-stories/chat-summary-pr-coverage-report-pages.md) | Documents the addition of code coverage, CI integration, and publishing to GitHub Pages. |
-| PR Summary: May 2024 | [chat-summary-pr-summary.md](docs/ai-stories/chat-summary-pr-summary.md) | High-level summary of recent PRs, dependency updates, and type mapping improvements. |
-| PR-235: Remote Schema Support & Javadoc Compliance | [pr-235-remote-schema-javadoc.md](docs/ai-stories/pr-235-remote-schema-javadoc.md) | Adds remote schema URL support, deterministic downloads, and documents the iterative Javadoc compliance process for Maven Central release. |
-
-# Usage
-
-Add the following to your pom files build/plugins section.
-
-```xml
-
 <plugin>
   <groupId>io.github.deweyjose</groupId>
   <artifactId>graphqlcodegen-maven-plugin</artifactId>
-  <version>1.24</version>
+  <version>3.8.0</version>
   <executions>
     <execution>
       <goals>
@@ -909,11 +30,805 @@ Add the following to your pom files build/plugins section.
     <schemaPaths>
       <param>src/main/resources/schema/schema.graphqls</param>
     </schemaPaths>
-    <packageName>com.acme.[your_project].generated</packageName>    
+    <packageName>com.acme.myproject.generated</packageName>
   </configuration>
 </plugin>
 ```
 
-# Generated Output
+If no `schemaPaths` is configured, the plugin looks in `src/main/resources/schema` for files with
+a `.graphqls`, `.graphql`, or `.gqls` extension.
 
-The generated types are available as part of the packageName.types package under build/generated. These are automatically added to your project's sources (no build-helper plugin required). The generated example data fetchers are available under build/generated-examples. Note that these are NOT added to your project's sources and serve mainly as a basic boilerplate code requiring further customization.
+### Generated output
+
+Generated types land under `${project.build.directory}/generated-sources` in the
+`<packageName>.types` package (client APIs under `.client`, and so on). The output directory is
+**automatically added to your project's compile source roots** — no build-helper plugin needed
+(disable with [`autoAddSource`](#autoaddsource)). Example data fetchers are written to
+`${project.build.directory}/generated-examples`; these are *not* added to your sources and serve
+as boilerplate to copy and customize.
+
+### Schema sources
+
+The plugin can pull schemas from four places, in any combination:
+
+- [`schemaPaths`](#schemapaths) — local files or directories (the default)
+- [`schemaJarFilesFromDependencies`](#schemajarfilesfromdependencies) — schemas embedded in dependency jars
+- [`schemaUrls`](#schemaurls) — remote schema files fetched over HTTP at build time
+- [`introspectionRequests`](#introspectionrequests) — live GraphQL introspection at build time
+
+## Example project
+
+A complete, multi-module example (server, jar-embedded schemas, type mappings, client API
+generation, live introspection) is vendored in this repository under
+[`examples/graphqlcodegen-example`](examples/graphqlcodegen-example) and builds as part of the
+reactor on every push.
+
+# Options
+
+Options are configured in the `<configuration>` element of the plugin.
+
+## Schema inputs
+
+### schemaPaths
+
+A list of schema file or directory paths, relative to the project or absolute. For directory
+paths, only files with the extensions `.graphql`, `.graphqls`, or `.gqls` are considered.
+
+- Type: array of paths
+- Required: false
+- Default: `${project.basedir}/src/main/resources/schema`
+
+```xml
+<schemaPaths>
+  <param>src/main/resources/schema/schema.graphqls</param>
+  <param>src/main/resources/someDirWithSchemas</param>
+</schemaPaths>
+```
+
+### schemaJarFilesFromDependencies
+
+Generate from schemas packaged inside dependency jars, referenced by `groupId:artifactId:version`
+coordinates. The `.graphql(s)` files must live under the `META-INF` folder of the jar. See the
+[official DGS docs](https://netflix.github.io/dgs/generating-code-from-schema/#generating-code-from-external-schemas-in-jars).
+
+- Type: array
+- Required: false
+- Default: `[]`
+
+```xml
+<schemaJarFilesFromDependencies>
+  <param>com.example:shared-schemas:1.0.0</param>
+</schemaJarFilesFromDependencies>
+```
+
+### schemaUrls
+
+Remote schema files to download (HTTP GET) at build time and include as codegen inputs. Downloads
+are stored deterministically under `<outputDir>/remote-schemas/` so incremental builds behave
+predictably.
+
+- Type: array
+- Required: false
+- Default: `[]`
+
+```xml
+<schemaUrls>
+  <param>https://raw.githubusercontent.com/acme/schemas/main/schema.graphqls</param>
+</schemaUrls>
+```
+
+### introspectionRequests
+
+> **Experimental:** this feature may change in future releases.
+
+Generate code from a schema fetched via GraphQL introspection (HTTP POST) at build time. Each
+`introspectionRequest` supports:
+
+- `url` (string, required): the GraphQL endpoint URL
+- `query` (string, optional): a custom introspection query; defaults to the standard full
+  introspection query
+- `operationName` (string, optional): defaults to `IntrospectionQuery`
+- `headers` (map, optional): HTTP headers to include in the request
+
+- Type: array of `introspectionRequest` objects
+- Required: false
+- Default: `[]`
+
+```xml
+<introspectionRequests>
+  <introspectionRequest>
+    <url>https://your-graphql-endpoint/graphql</url>
+    <headers>
+      <Authorization>Bearer ${env.YOUR_TOKEN}</Authorization>
+      <Content-Type>application/json</Content-Type>
+    </headers>
+  </introspectionRequest>
+</introspectionRequests>
+```
+
+## Core options
+
+### packageName
+
+The base package for generated code. Sub-packages are appended per kind of generated class (see
+the `subPackageName*` options).
+
+- Type: string
+- Required: true
+
+```xml
+<packageName>com.acme.generated</packageName>
+```
+
+### language
+
+`java` or `kotlin`.
+
+- Type: string
+- Required: false
+- Default: `java`
+
+```xml
+<language>kotlin</language>
+```
+
+### skip
+
+Skip code generation entirely. Also settable from the command line via
+`-Ddgs.codegen.skip=true`.
+
+- Type: boolean
+- Required: false
+- Default: `false`
+
+```xml
+<skip>true</skip>
+```
+
+### onlyGenerateChanged
+
+Only regenerate when schema files have changed since the last build (tracked via a manifest of
+schema hashes — see [`schemaManifestOutputDir`](#schemamanifestoutputdir)). Change detection
+applies to `schemaPaths` only; jar, URL, and introspection schemas are always regenerated.
+
+- Type: boolean
+- Required: false
+- Default: `true`
+
+```xml
+<onlyGenerateChanged>true</onlyGenerateChanged>
+```
+
+### typeMapping
+
+Map GraphQL types to existing Java/Kotlin classes instead of generating them.
+
+- Type: map
+- Required: false
+
+```xml
+<typeMapping>
+  <Date>java.time.LocalDateTime</Date>
+</typeMapping>
+```
+
+### typeMappingPropertiesFiles
+
+One or more type-mapping properties files loaded from the **compile classpath of dependency
+jars**. Entries are merged into `typeMapping`; explicit `<typeMapping>` entries win on conflict.
+
+- Type: array
+- Required: false
+
+```xml
+<typeMappingPropertiesFiles>
+  <typeMappingPropertiesFile>graphql/common-type-mappings.properties</typeMappingPropertiesFile>
+</typeMappingPropertiesFiles>
+```
+
+### localTypeMappingPropertiesFiles
+
+One or more type-mapping properties files from the **local project**, relative to the project
+root. Entries are merged into `typeMapping`; explicit `<typeMapping>` entries win on conflict.
+
+- Type: array
+- Required: false
+
+```xml
+<localTypeMappingPropertiesFiles>
+  <localTypeMappingPropertiesFile>src/main/resources/type-mapping.properties</localTypeMappingPropertiesFile>
+</localTypeMappingPropertiesFiles>
+```
+
+## Output locations
+
+### outputDir
+
+Where generated sources are written.
+
+- Type: string
+- Required: false
+- Default: `${project.build.directory}/generated-sources`
+
+```xml
+<outputDir>${project.build.directory}/generated-sources</outputDir>
+```
+
+### autoAddSource
+
+Automatically add `outputDir` to the Maven compile source roots. Eliminates the need for the
+build-helper-maven-plugin in most setups.
+
+- Type: boolean
+- Required: false
+- Default: `true`
+
+```xml
+<autoAddSource>true</autoAddSource>
+```
+
+### examplesOutputDir
+
+Where generated example data fetchers are written. (Not added to compile sources.)
+
+- Type: string
+- Required: false
+- Default: `${project.build.directory}/generated-examples`
+
+```xml
+<examplesOutputDir>${project.build.directory}/generated-examples</examplesOutputDir>
+```
+
+### schemaManifestOutputDir
+
+Where the schema-hash manifest for [`onlyGenerateChanged`](#onlygeneratechanged) is stored.
+
+- Type: string
+- Required: false
+- Default: `${project.build.directory}/graphqlcodegen`
+
+```xml
+<schemaManifestOutputDir>${project.build.directory}/graphqlcodegen</schemaManifestOutputDir>
+```
+
+### writeToFiles
+
+Write generated sources to disk. Disabling this effectively turns codegen into a dry run.
+
+- Type: boolean
+- Required: false
+- Default: `true`
+
+```xml
+<writeToFiles>true</writeToFiles>
+```
+
+## Sub-package names
+
+### subPackageNameClient
+
+- Type: string
+- Required: false
+- Default: `client`
+
+```xml
+<subPackageNameClient>client</subPackageNameClient>
+```
+
+### subPackageNameDatafetchers
+
+- Type: string
+- Required: false
+- Default: `datafetchers`
+
+```xml
+<subPackageNameDatafetchers>datafetchers</subPackageNameDatafetchers>
+```
+
+### subPackageNameTypes
+
+- Type: string
+- Required: false
+- Default: `types`
+
+```xml
+<subPackageNameTypes>types</subPackageNameTypes>
+```
+
+### subPackageNameDocs
+
+- Type: string
+- Required: false
+- Default: `docs`
+
+```xml
+<subPackageNameDocs>docs</subPackageNameDocs>
+```
+
+## Data types & interfaces
+
+### generateDataTypes
+
+Generate data types (POJOs) for schema types. Useful to disable when only generating a client
+API against types that already exist.
+
+- Type: boolean
+- Required: false
+- Default: `true`
+
+```xml
+<generateDataTypes>true</generateDataTypes>
+```
+
+### generateInterfaces
+
+Generate interfaces for data classes.
+
+- Type: boolean
+- Required: false
+- Default: `false`
+
+```xml
+<generateInterfaces>true</generateInterfaces>
+```
+
+### generateInterfaceSetters
+
+Generate setters on generated interfaces.
+
+- Type: boolean
+- Required: false
+- Default: `false`
+
+```xml
+<generateInterfaceSetters>true</generateInterfaceSetters>
+```
+
+### generateInterfaceMethodsForInterfaceFields
+
+- Type: boolean
+- Required: false
+- Default: `false`
+
+```xml
+<generateInterfaceMethodsForInterfaceFields>true</generateInterfaceMethodsForInterfaceFields>
+```
+
+### generateBoxedTypes
+
+Use boxed types (e.g. `Integer` instead of `int`) for non-nullable primitive fields.
+
+- Type: boolean
+- Required: false
+- Default: `false`
+
+```xml
+<generateBoxedTypes>true</generateBoxedTypes>
+```
+
+### generateIsGetterForPrimitiveBooleanFields
+
+Generate `is`-prefixed getters for primitive boolean fields.
+
+- Type: boolean
+- Required: false
+- Default: `false`
+
+```xml
+<generateIsGetterForPrimitiveBooleanFields>true</generateIsGetterForPrimitiveBooleanFields>
+```
+
+### javaGenerateAllConstructor
+
+Generate an all-args constructor on generated Java data types.
+
+- Type: boolean
+- Required: false
+- Default: `false`
+
+```xml
+<javaGenerateAllConstructor>true</javaGenerateAllConstructor>
+```
+
+### implementSerializable
+
+Generated data types implement `java.io.Serializable`.
+
+- Type: boolean
+- Required: false
+- Default: `false`
+
+```xml
+<implementSerializable>true</implementSerializable>
+```
+
+### snakeCaseConstantNames
+
+- Type: boolean
+- Required: false
+- Default: `false`
+
+```xml
+<snakeCaseConstantNames>true</snakeCaseConstantNames>
+```
+
+### trackInputFieldSet
+
+Generate `has<FieldName>()` methods that track which fields were explicitly set on input types —
+useful for distinguishing "explicitly set to null" from "never set".
+
+- Type: boolean
+- Required: false
+- Default: `false`
+
+```xml
+<trackInputFieldSet>true</trackInputFieldSet>
+```
+
+## Client API generation
+
+### generateClientApi
+
+Generate typed query/projection builder classes for use in GraphQL clients.
+
+- Type: boolean
+- Required: false
+- Default: `false`
+
+```xml
+<generateClientApi>true</generateClientApi>
+```
+
+### includeQueries
+
+Limit client API generation to the listed query fields. Used with `generateClientApi`.
+
+- Type: array
+- Required: false
+- Default: `[]` (all queries)
+
+```xml
+<includeQueries>
+  <param>shows</param>
+  <param>theaters</param>
+</includeQueries>
+```
+
+### includeMutations
+
+Limit client API generation to the listed mutation fields. Used with `generateClientApi`.
+
+- Type: array
+- Required: false
+- Default: `[]` (all mutations)
+
+```xml
+<includeMutations>
+  <param>addShow</param>
+</includeMutations>
+```
+
+### includeSubscriptions
+
+Limit client API generation to the listed subscription fields. Used with `generateClientApi`.
+
+- Type: array
+- Required: false
+- Default: `[]` (all subscriptions)
+
+```xml
+<includeSubscriptions>
+  <param>showAdded</param>
+</includeSubscriptions>
+```
+
+### skipEntityQueries
+
+Skip generating federated `_entities` queries.
+
+- Type: boolean
+- Required: false
+- Default: `false`
+
+```xml
+<skipEntityQueries>true</skipEntityQueries>
+```
+
+### shortProjectionNames
+
+- Type: boolean
+- Required: false
+- Default: `false`
+
+```xml
+<shortProjectionNames>true</shortProjectionNames>
+```
+
+## Kotlin
+
+### generateKotlinNullableClasses
+
+- Type: boolean
+- Required: false
+- Default: `false`
+
+```xml
+<generateKotlinNullableClasses>true</generateKotlinNullableClasses>
+```
+
+### generateKotlinClosureProjections
+
+- Type: boolean
+- Required: false
+- Default: `false`
+
+```xml
+<generateKotlinClosureProjections>true</generateKotlinClosureProjections>
+```
+
+### kotlinAllFieldsOptional
+
+- Type: boolean
+- Required: false
+- Default: `false`
+
+```xml
+<kotlinAllFieldsOptional>true</kotlinAllFieldsOptional>
+```
+
+## Annotations
+
+### addGeneratedAnnotation
+
+Add a `@Generated` annotation to generated classes.
+
+- Type: boolean
+- Required: false
+- Default: `false`
+
+```xml
+<addGeneratedAnnotation>true</addGeneratedAnnotation>
+```
+
+### disableDatesInGeneratedAnnotation
+
+Omit the timestamp from the `@Generated` annotation (keeps generated code reproducible).
+
+- Type: boolean
+- Required: false
+- Default: `false`
+
+```xml
+<disableDatesInGeneratedAnnotation>true</disableDatesInGeneratedAnnotation>
+```
+
+### generatedAnnotationType
+
+Fully-qualified class name of the `@Generated` annotation to apply to generated types. When
+unset, graphql-dgs-codegen-core uses its default (`<packageName>.Generated`). Added in
+graphql-dgs-codegen-core 8.5.0.
+
+- Type: string
+- Required: false
+- Default: (unset)
+
+```xml
+<generatedAnnotationType>javax.annotation.processing.Generated</generatedAnnotationType>
+```
+
+### addDeprecatedAnnotation
+
+Add `@Deprecated` to generated members for schema fields marked `@deprecated`.
+
+- Type: boolean
+- Required: false
+- Default: `false`
+
+```xml
+<addDeprecatedAnnotation>true</addDeprecatedAnnotation>
+```
+
+### generateJSpecifyAnnotations
+
+Generate [JSpecify](https://jspecify.dev/) null-safety annotations in generated Java code:
+classes are annotated with `@NullMarked` and nullable members with `@Nullable`.
+
+- Type: boolean
+- Required: false
+- Default: `false`
+
+```xml
+<generateJSpecifyAnnotations>true</generateJSpecifyAnnotations>
+```
+
+### generateCustomAnnotations
+
+Generate custom annotations from `@annotate` directives in the schema. Used with
+`includeImports`, `includeEnumImports`, and `includeClassImports`.
+
+- Type: boolean
+- Required: false
+- Default: `false`
+
+```xml
+<generateCustomAnnotations>true</generateCustomAnnotations>
+```
+
+### includeImports
+
+Maps custom annotation names to their packages. Only used when `generateCustomAnnotations` is
+enabled.
+
+- Type: map<string, string>
+- Required: false
+
+```xml
+<includeImports>
+  <validator>com.test.validator</validator>
+</includeImports>
+```
+
+### includeEnumImports
+
+Maps annotation enum arguments to their packages. Only used when `generateCustomAnnotations` is
+enabled.
+
+- Type: map<string, map<string, string>>
+- Required: false
+
+```xml
+<includeEnumImports>
+  <someAnnotation>
+    <properties>
+      <sortBy>com.test.enums</sortBy>
+    </properties>
+  </someAnnotation>
+</includeEnumImports>
+```
+
+### includeClassImports
+
+Maps annotation class-name arguments to their packages. Only used when
+`generateCustomAnnotations` is enabled.
+
+- Type: map<string, map<string, string>>
+- Required: false
+
+```xml
+<includeClassImports>
+  <someAnnotation>
+    <properties>
+      <BasicValidation>com.test.validators</BasicValidation>
+    </properties>
+  </someAnnotation>
+</includeClassImports>
+```
+
+## Docs generation
+
+### generateDocs
+
+Generate schema documentation.
+
+- Type: boolean
+- Required: false
+- Default: `false`
+
+```xml
+<generateDocs>true</generateDocs>
+```
+
+### generatedDocsFolder
+
+Folder for generated documentation.
+
+- Type: string
+- Required: false
+- Default: `./generated-docs`
+
+```xml
+<generatedDocsFolder>${project.build.directory}/generated-docs</generatedDocsFolder>
+```
+
+## Deprecated / no-op options
+
+These parameters are still accepted so existing POMs keep parsing, but they no longer have any
+effect because the underlying option was removed from `graphql-dgs-codegen-core`:
+
+| Option | Status |
+|--------|--------|
+| `generateClientApiv2` | No-op since graphql-dgs-codegen-core 8.4.0 (v2 client API consolidated). Use [`generateClientApi`](#generateclientapi). |
+| `omitNullInputFields` | No-op with graphql-dgs-codegen-core >= 8.2.1 (option removed upstream). The plugin logs a warning if set. |
+| `maxProjectionDepth` | Accepted but not forwarded to codegen (option removed upstream). |
+
+# Architecture
+
+This project is a multi-module Maven reactor. The root `pom.xml` is a `pom`-packaging
+aggregator; the published artifact lives in the `graphqlcodegen-maven-plugin` module. The example
+project is vendored in and wired as Maven modules that build **by default**, so a single
+`./mvnw install` runs the plugin's unit tests and the example tests together. Release stays
+plugin-only (scoped with `-pl`), and Spring Boot lives only in the example modules.
+
+```
+.                                    # aggregator (pom)
+├── graphqlcodegen-maven-plugin/     # the published plugin
+└── examples/graphqlcodegen-example/ # end-to-end harness (built by default)
+    ├── common/  server/  client/  client-introspection/
+```
+
+## graphqlcodegen-maven-plugin
+
+The Maven plugin that users apply to their projects. It is responsible for:
+
+- Accepting configuration via plugin parameters (the options documented above).
+- Resolving schema files from the local project, dependency jars, remote URLs, and introspection.
+- Invoking the DGS codegen library with the correct configuration.
+- Managing incremental generation via schema-hash manifest tracking.
+- Holding a checked-in `CodeGenConfigBuilder` that mirrors the upstream `CodeGenConfig`
+  constructor shape.
+
+## examples/graphqlcodegen-example
+
+A vendored, multi-module DGS project that exercises the plugin end to end: jar-embedded schemas,
+remote/introspection schemas, type mappings, and client-API generation. It builds **by default**
+(plugin first in reactor order, so the examples use the just-built plugin) and is validated on
+every push by the **E2E Example** GitHub Actions workflow. The `client-introspection` module
+starts its own DGS server for live introspection, so no externally-running server is needed.
+Spring Boot and the DGS framework live entirely in these modules and never enter the plugin's
+own build (a `maven-enforcer` rule bans Spring Boot from the plugin).
+
+# Contributing
+
+### GitHub issues
+
+Feel free to create a GitHub issue for requests to integrate with newer
+[releases](https://github.com/Netflix/dgs-codegen/releases) of the core DGS codegen library.
+
+### PRs
+
+PRs are welcome. Typically, new plugin options are needed when the
+[CodeGenConfig](https://github.com/Netflix/dgs-codegen/blob/master/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/CodeGen.kt)
+constructor in the core library changes. When constructor parameters change upstream:
+
+- Update `CodeGenConfigBuilder` to match the latest constructor shape and ordering.
+- Wire new options through `Codegen.java`, `CodegenConfigProvider.java`, and
+  `CodegenExecutor.java` (all under
+  `graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen`).
+- Add/update tests and document the option in this README.
+
+See [AGENTS.md](AGENTS.md) and
+[graphqlcodegen-maven-plugin/AGENTS.md](graphqlcodegen-maven-plugin/AGENTS.md) for a detailed
+walkthrough of the codebase, conventions, and the option-wiring checklist.
+
+Release checklist:
+
+1. Bump the version in both [`graphqlcodegen-maven-plugin/pom.xml`](graphqlcodegen-maven-plugin/pom.xml)
+   and the root aggregator [`pom.xml`](pom.xml), and the example's
+   `graphql-codegen-plugin.version` property (keep all three in sync).
+2. Run `./mvnw spotless:apply install` locally — this builds and tests the plugin **and** the
+   example modules.
+3. Publish a GitHub Release with tag `graphqlcodegen-maven-plugin-<version>`; the release event
+   triggers the publish workflow, which deploys to Maven Central.
+
+## Testing with the example project
+
+The example project lives in `examples/graphqlcodegen-example` and builds by default as part of
+the reactor, against the plugin you just built. A single command runs the plugin unit tests and
+the example tests (including the `client-introspection` module, which starts its own DGS server):
+
+```bash
+./mvnw -B -ntp install
+```
+
+`install` (not `verify`) ensures the plugin is installed first so the examples resolve it. The
+`server` module fetches its schema over HTTP from `main` by default; to build fully offline,
+serve the in-repo schema and override the URL:
+
+```bash
+python3 -m http.server 8000 \
+  --directory examples/graphqlcodegen-example/server/src/main/resources/schema &
+./mvnw -B -ntp install -Dcodegen.server.schemaUrl=http://localhost:8000/main.graphqls
+```
+
+The **E2E Example** CI workflow runs exactly this on every push (see
+[`.github/workflows/e2e-example.yaml`](.github/workflows/e2e-example.yaml)).

--- a/examples/graphqlcodegen-example/AGENTS.md
+++ b/examples/graphqlcodegen-example/AGENTS.md
@@ -1,42 +1,48 @@
-# AGENTS.md
+# AGENTS.md — examples/graphqlcodegen-example (vendored e2e harness)
 
-Guidance for AI agents making changes in this repository. Read this before editing — it
-encodes the architecture, the conventions, and the gotchas that are easy to miss.
+Guidance for AI agents editing the example harness. Read the repo-root `AGENTS.md` first for
+reactor layout, build commands, and CI; this file covers what each example module demonstrates
+and how to extend it.
 
-## What this project is
+## What this is
 
-A **demo/reference project** showing how to consume the
-[`io.github.deweyjose:graphqlcodegen-maven-plugin`](https://github.com/deweyjose/graphqlcodegen)
-(which wraps Netflix DGS codegen) in a real multi-module Maven build. It is *not* the plugin
+A **vendored copy** of the [`deweyjose/graphqlcodegen-example`](https://github.com/deweyjose/graphqlcodegen-example)
+demo project, wired into this repo's Maven reactor as **default modules**. It is *not* the plugin
 itself — it exists to exercise and document the plugin's configuration surface end to end:
 schema files, jar-embedded schemas, remote schema URLs, GraphQL introspection, type mappings,
-and client-API generation.
+and client-API generation. The files here are the **source of truth** — edit them directly; there
+is no submodule or sync step.
 
-- Multi-module Maven build. Parent is Spring Boot (`spring-boot-starter-parent`). Java **17**
-  (`.tool-versions` pins `temurin-17.0.7+7`).
-- Modules: **`common`**, **`server`**, **`client`**, **`client-introspection`** (declared in
-  root `pom.xml`).
-- The plugin version is centralized in the root `pom.xml` property
-  `graphql-codegen-plugin.version`. Currently **3.7.3** (latest — check
-  `gh release list -R deweyjose/graphqlcodegen` before bumping).
+- Parent pom is Spring Boot (`spring-boot-starter-parent`). Java **17**. Spring Boot must never
+  leak into the plugin module (enforced there by maven-enforcer).
+- Modules, in reactor order: **`common`** → **`server`** → **`client`** → **`client-introspection`**.
+- The plugin version is centralized in this directory's root `pom.xml` property
+  **`graphql-codegen-plugin.version`** and must stay **in sync with the in-repo plugin version**
+  (root aggregator + `graphqlcodegen-maven-plugin/pom.xml`). No release lookup needed — the
+  version to match lives in this repo.
 
 ## Build & run
 
-Use the system `mvn` — this repo has no Maven wrapper.
+Build from the **repo root** with the Maven wrapper — the examples resolve the *just-built*
+plugin only when the whole reactor runs with `install`:
 
 ```bash
-mvn -B install                 # build all modules; runs codegen + tests
-mvn -B -pl server test         # tests for a single module
+./mvnw -B -ntp install                              # plugin + all example modules (the e2e test)
+./mvnw -B -ntp install -pl examples/graphqlcodegen-example/server -am   # one example module + its deps
 ```
 
-Codegen is bound to `generate-sources` and runs automatically during the build. Generated
-sources land in `target/generated-sources` and are **not** checked in.
+The `server` module's codegen fetches `codegen.server.schemaUrl` over HTTP (defaults to the
+schema on `main`). To build offline, serve the in-repo schema and override the property — see
+the root `AGENTS.md`.
 
-To see it in action (the `client-introspection` build needs the server running):
+Codegen is bound to `generate-sources` and runs automatically. Generated sources land in each
+module's `target/generated-sources` and are **not** checked in.
+
+To run the demo interactively (from this directory):
 
 ```bash
-cd server && mvn spring-boot:run          # starts GraphQL server on http://localhost:8080/graphql
-cd client && mvn spring-boot:run          # queries the server, prints shows/theaters
+cd server && mvn spring-boot:run     # GraphQL server on http://localhost:8080/graphql
+cd client && mvn spring-boot:run     # queries the server, prints shows/theaters
 ```
 
 ## Module architecture — what each one demonstrates
@@ -47,38 +53,44 @@ cd client && mvn spring-boot:run          # queries the server, prints shows/the
    generated code maps onto) and `graphql/common-type-mappings.properties` (a classpath
    type-mapping file consumed via `<typeMappingPropertiesFiles>`).
 2. **`server`** — DGS Spring Boot GraphQL server. Demonstrates the **widest plugin config**:
-   local `<schemaPaths>`, a remote `<schemaUrls>`, jar-embedded schemas, and both local
-   (`<localTypeMappingPropertiesFiles>`) and classpath (`<typeMappingPropertiesFiles>`) type
-   mappings. Datafetchers under `datafetchers/` resolve the schema; services under `services/`
-   back them. Generated types use package `com.acme`.
+   local `<schemaPaths>`, a remote `<schemaUrls>` (the `codegen.server.schemaUrl` property),
+   jar-embedded schemas, and both local (`<localTypeMappingPropertiesFiles>`) and classpath
+   (`<typeMappingPropertiesFiles>`) type mappings. Datafetchers under `datafetchers/` resolve the
+   schema; services under `services/` back them. `ShowsDatafetcherTest` is the DGS runtime test
+   that makes this a real e2e check. Generated types use package `com.acme`.
 3. **`client`** — DGS client. Demonstrates **client-API generation** (`<generateClientApi>`,
-   `<includeQueries>`) plus inline `<typeMapping>`. `Main.java` builds typed queries with the
-   generated `*GraphQLQuery` / `*ProjectionRoot` classes (package `com.acme`).
+   `<includeQueries>`), inline `<typeMapping>`, and `<autoAddSource>false</autoAddSource>` with
+   the build-helper plugin instead. `Main.java` builds typed queries with the generated
+   `*GraphQLQuery` / `*ProjectionRoot` classes (package `com.acme`).
 4. **`client-introspection`** — same as `client`, but the schema comes from **live GraphQL
    introspection** (`<introspectionRequests>` against `http://localhost:8080/graphql`).
-   Generated types use package `com.acme.introspection`. **This module's build requires the
-   server to be running** — that's the intended demonstration, not a bug.
+   **Self-contained:** its pom binds the `spring-boot-maven-plugin` `start`/`stop` goals around
+   codegen, so it launches the `server` app itself during the build — no externally-running
+   server needed. Don't remove those executions or the `server` dependency. Generated types use
+   package `com.acme.introspection`.
 
 ## How the plugin is wired
 
-The plugin is declared once in the root `pom.xml` `<pluginManagement>` (binding the `generate`
-goal + global options like `addGeneratedAnnotation`), then each module adds its own `<plugin>`
-block under `<build><plugins>` with module-specific `<configuration>`. To change generation
-behavior, edit the relevant module's `<configuration>` — the four modules deliberately use
-different option combinations, so don't assume a change in one applies to the others.
+The plugin is declared once in this directory's root `pom.xml` `<pluginManagement>` (binding the
+`generate` goal + global options like `addGeneratedAnnotation`), then each module adds its own
+`<plugin>` block under `<build><plugins>` with module-specific `<configuration>`. To change
+generation behavior, edit the relevant module's `<configuration>` — the four modules deliberately
+use different option combinations, so don't assume a change in one applies to the others.
 
 ## The most common task: showcasing a plugin option
 
-This repo's purpose is to be a living example. When the plugin gains a feature worth
+This harness's purpose is to be a living example. When the plugin gains a feature worth
 demonstrating:
 
-1. Bump `graphql-codegen-plugin.version` in the root `pom.xml` to a version that has it.
-2. Add the `<configuration>` option to whichever module best illustrates it.
-3. Add schema/fixtures under that module's `src/main/resources/schema/` (or
-   `common`'s `META-INF/schema/` for jar-shared schemas) if the option needs them.
-4. Reference the new generated code from `Main.java` / datafetchers so the build actually
+1. Add the `<configuration>` option to whichever module best illustrates it.
+2. Add schema/fixtures under that module's `src/main/resources/schema/` (or `common`'s
+   `META-INF/schema/` for jar-shared schemas) if the option needs them.
+3. Reference the new generated code from `Main.java` / datafetchers / tests so the build actually
    compiles against it — that proves the option works, which is the whole point.
-5. `mvn -B install` must be green (build the full reactor, not just one module).
+4. `./mvnw -B -ntp install` from the repo root must be green (full reactor, not just one module).
+5. If the release bumping the plugin version hasn't happened yet, the examples still work: the
+   reactor installs the in-repo plugin at the current version first, and
+   `graphql-codegen-plugin.version` points at that version.
 
 ## Conventions & gotchas
 
@@ -89,17 +101,12 @@ demonstrating:
 - **Generated package names are intentional**: `com.acme` (client/server),
   `com.acme.introspection` (introspection). `Main.java` imports from these — renaming a
   `<packageName>` breaks the imports.
-- **`client-introspection` will fail to build with the server down.** Start the server first.
 - **Generated sources are not committed** and live in `target/`; never edit generated files —
   change the schema or the plugin config instead.
 - **Hand-written vs generated types**: `common/Show.java` is hand-written and wired in via type
   mappings so the generated code reuses it. Don't let codegen regenerate a competing `Show`.
 - The `client` schema includes a `doNotCodeGen` query intentionally excluded via
   `<includeQueries>` — it demonstrates query filtering; leave it as a negative example.
-
-## When asked to "update to the latest plugin"
-
-The plugin lives at `deweyjose/graphqlcodegen`. Get the real latest from
-`gh release list -R deweyjose/graphqlcodegen` (the Maven Central search API lags). Update only
-the `graphql-codegen-plugin.version` property in the root `pom.xml`, then run `mvn -B install`
-to confirm the new version still generates and compiles across all modules.
+- **`codegen.server.schemaUrl` must stay overridable.** CI points it at a locally-served copy of
+  the in-repo schema; if you rename the property or hardcode the URL, the E2E and coverage
+  workflows break. `RemoteSchemaService` is HTTP-only — a `file:` URL won't work.

--- a/examples/graphqlcodegen-example/README.md
+++ b/examples/graphqlcodegen-example/README.md
@@ -1,24 +1,43 @@
 # graphqlcodegen-example
-This repo provides a simple example project that uses graphqlcodegen. 
-Start the server and run the client to see it in action.
 
-## Clone the repo
+A multi-module example project for the
+[graphqlcodegen-maven-plugin](https://github.com/deweyjose/graphqlcodegen), vendored into the
+plugin's repository and built as part of its reactor on every push.
+
+It demonstrates the plugin's main features across four modules:
+
+| Module | Demonstrates |
+|--------|--------------|
+| `common` | Schemas packaged in a jar (`META-INF/schema/`) + shared type-mapping properties |
+| `server` | DGS Spring Boot server; local schema paths, remote `schemaUrls`, jar-embedded schemas, local + classpath type mappings |
+| `client` | Typed client-API generation (`generateClientApi`, `includeQueries`) |
+| `client-introspection` | Codegen from **live GraphQL introspection** (self-starts the server during the build) |
+
+## Build
+
+From the repository root (this installs the plugin first, then builds the examples against it):
+
 ```console
-git clone https://github.com/deweyjose/graphqlcodegen-example.git
-cd graphqlcodegen-example
+./mvnw -B -ntp install
 ```
 
-## Start the server
+See [AGENTS.md](AGENTS.md) for details, including how to build offline by overriding
+`codegen.server.schemaUrl`.
+
+## Run the demo
+
+Start the server (GraphQL endpoint on `http://localhost:8080/graphql`):
+
 ```console
-$ cd server 
-$ mvn spring-boot:run
+cd server
+mvn spring-boot:run
 ```
 
-## Run the client
-This will query the server for a list of shows and print them to the console.
+Then run the client, which queries the server for shows and theaters using the generated typed
+query API:
+
 ```console
-$ cd ../client
-$ mvn spring-boot:run
+cd ../client
+mvn spring-boot:run
 {shows=[{id=1, title=Stranger Things}, {id=2, title=Ozark}, {id=3, title=The Crown}, {id=4, title=Dead to Me}, {id=5, title=Orange is the New Black}]}
-
 ```

--- a/graphqlcodegen-maven-plugin/AGENTS.md
+++ b/graphqlcodegen-maven-plugin/AGENTS.md
@@ -1,0 +1,94 @@
+# AGENTS.md — graphqlcodegen-maven-plugin (the published plugin)
+
+Module-level guidance for the plugin itself. Read the repo-root `AGENTS.md` first for
+reactor layout, build commands, CI, and release; this file covers the code in this module.
+
+## Layout
+
+```
+src/main/java/io/github/deweyjose/graphqlcodegen/
+├── Codegen.java                 # the @Mojo — every user-facing option is an @Parameter here
+├── CodegenConfigProvider.java   # getter interface the executor reads (Codegen implements it)
+├── CodegenExecutor.java         # orchestrates schema resolution + forwards options to the builder
+├── CodeGenConfigBuilder.java    # checked-in builder mirroring upstream DGS CodeGenConfig
+├── Logger.java / MavenLogger.java  # logging abstraction (services don't depend on Maven APIs)
+├── parameters/                  # structured @Parameter value types
+│   ├── IntrospectionRequest.java   # url/query/operationName/headers
+│   └── ParameterMap.java           # nested map support for includeEnumImports/includeClassImports
+└── services/                    # focused helpers, each independently unit-tested
+    ├── SchemaFileService.java          # expands/resolves schema paths + jar-embedded schemas
+    ├── RemoteSchemaService.java        # HTTP GET schema files; HTTP POST introspection → SDL
+    ├── SchemaTransformationService.java # schema normalization (root-type renaming, scalars)
+    ├── SchemaManifestService.java      # schema hashes for onlyGenerateChanged incremental builds
+    ├── TypeMappingService.java         # merges typeMapping (inline > classpath > local files)
+    └── Constants.java                  # default introspection query/operation name
+```
+
+## Request flow
+
+`Codegen.execute()` → builds services → `CodegenExecutor.execute(this, artifacts, basedir)`:
+
+1. Expand `schemaPaths` (directories → `.graphql`/`.graphqls`/`.gqls` files).
+2. Resolve jar-embedded schemas (`META-INF/**` in dependency jars), remote `schemaUrls`
+   (saved under `<outputDir>/remote-schemas/<base64(url)>.graphqls` for deterministic
+   incremental behavior), and `introspectionRequests` (introspection JSON → SDL via
+   graphql-java).
+3. If `onlyGenerateChanged`, filter to files whose hash changed vs. the manifest
+   (applies to `schemaPaths` only); short-circuit if nothing to do.
+4. Merge type mappings (`typeMapping` wins over properties files).
+5. Build `CodeGenConfig` via `CodeGenConfigBuilder`, run DGS `CodeGen.generate()`,
+   then sync the manifest.
+6. Back in the Mojo: if `autoAddSource`, add `outputDir` as a compile source root.
+
+## Checklist: exposing a new DGS codegen option
+
+An option existing in upstream `CodeGenConfig` is **not enough** — it must be wired through
+all layers or it is silently unreachable from Maven:
+
+1. Confirm the option exists in the pinned `graphql-dgs-codegen-core.version` (property in
+   this module's `pom.xml`). Check upstream release notes before bumping — often the fix is
+   wiring, not a version bump.
+2. Add an `@Parameter` field (with default) in `Codegen.java`.
+3. Add the getter to `CodegenConfigProvider.java` (and to the test double
+   `src/test/java/.../TestCodegenProvider.java`).
+4. Forward it to the builder in `CodegenExecutor.java`.
+5. Ensure `CodeGenConfigBuilder.java` sets it on the DGS config — its `build()` call must
+   match the upstream constructor's **exact argument order**.
+6. Add/extend tests in `CodegenExecutorTest` and fixtures under `src/test/resources/schema`.
+7. Document the option in the root `README.md` — it is the consumer-facing option reference,
+   and its stated **types and defaults must match the `@Parameter` declarations** (they have
+   drifted before).
+
+## Conventions & gotchas
+
+- **`CodeGenConfigBuilder` is checked in, not generated.** When bumping
+  `graphql-dgs-codegen-core.version`, diff its fields and `build()` argument list against the
+  upstream `CodeGenConfig` constructor.
+- **Primitive `boolean` options hide gaps.** A missing setter call does not fail compilation —
+  the field just stays `false` — so a feature can look wired but be inert. Add a test that
+  asserts the option actually takes effect.
+- **Known intentional no-ops** (kept for POM compatibility; do not "fix" them by wiring them
+  up without checking upstream first): `generateClientApiv2` (removed upstream in 8.4.0),
+  `omitNullInputFields` (removed upstream in 8.2.1; executor logs a warning),
+  `maxProjectionDepth` (parameter + getter exist but it is not forwarded — removed upstream).
+- **Mojo is `threadSafe = true`.** No shared mutable static state in the request path.
+- **Lombok** (`@Getter`, `@SneakyThrows`, …) is used; don't hand-write accessors it generates.
+- **Services must not depend on Maven APIs** — they take the `Logger` abstraction, which is
+  what keeps them unit-testable without a Maven harness. Keep it that way.
+- **Spring Boot is banned** from this module's classpath (maven-enforcer `ban-spring-boot`).
+  The DGS framework core (`com.netflix.graphql.dgs:graphql-dgs`) is a legitimate transitive
+  of `graphql-dgs-codegen-core` and is intentionally allowed.
+- Prefer **name-based test assertions** over hardcoded counts (assert a fixture name is
+  present, not that there are exactly N fixtures).
+
+## Build & test (from the repo root)
+
+```bash
+./mvnw -B -ntp verify -pl graphqlcodegen-maven-plugin    # this module only (what Java CI runs)
+./mvnw test -pl graphqlcodegen-maven-plugin -Dtest=CodegenExecutorTest   # single class
+./mvnw spotless:apply -pl graphqlcodegen-maven-plugin    # ALWAYS before committing
+./mvnw -B -ntp install                                   # full reactor incl. example e2e — the definition of done
+```
+
+Test resources: `src/test/resources/schema` (unit fixtures), `src/test/resources/introspection`
+(canned introspection query/response for `RemoteSchemaServiceTest`).


### PR DESCRIPTION
## Summary

This PR reorganizes the repository documentation to improve clarity and maintainability. The main README is restructured into a consumer-facing reference guide, and new module-level AGENTS.md files are added to guide contributors working on specific parts of the codebase.

## Key changes

- **README.md**: Completely reorganized from a narrative format into a structured reference guide
  - Moved quick-start and configuration examples to the top
  - Grouped all ~50 plugin options into logical sections (schema inputs, core options, output locations, data types, client API, Kotlin, annotations, docs)
  - Moved architecture and contribution guidance to the end
  - Improved clarity with consistent formatting and cross-references

- **New `graphqlcodegen-maven-plugin/AGENTS.md`**: Added module-level contributor guidance
  - Documents the plugin module's code layout and request flow
  - Provides a checklist for exposing new DGS codegen options
  - Explains the seam between the plugin and upstream DGS codegen (the `CodeGenConfigBuilder`)
  - Lists module-specific gotchas and testing patterns

- **New `examples/graphqlcodegen-example/AGENTS.md`**: Added example harness contributor guidance
  - Clarifies that the example is a vendored copy (not a submodule)
  - Documents what each of the four modules demonstrates
  - Provides build commands and interactive demo instructions
  - Explains how to extend the example with new scenarios

- **Root `AGENTS.md`**: Enhanced with a doc map
  - Added cross-references to the new module-level AGENTS.md files
  - Clarified the relationship between code changes and documentation updates
  - Kept reactor layout, build commands, CI, and release guidance

- **`examples/graphqlcodegen-example/README.md`**: Simplified to focus on running the demo
  - Removed redundant setup instructions
  - Added a table showing what each module demonstrates
  - Linked to AGENTS.md for detailed contributor guidance

## Notable implementation details

- No source code changes to the plugin itself — this is purely documentation reorganization
- The README now serves as the authoritative option reference; its documented defaults and types must stay in sync with `@Parameter` declarations in `Codegen.java`
- The module-level AGENTS.md files encode architectural decisions and common pitfalls to help contributors avoid mistakes when extending the plugin or examples

https://claude.ai/code/session_01ExPXZkjCbZaVPtrgmW93pk