### PR TITLE
Upgrade: graphql-dgs-codegen-core 8.5.0 -> 8.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,7 +645,10 @@ classes are annotated with `@NullMarked` and nullable members with `@Nullable`.
 
 Select which Jackson major version(s) the generated code targets. `2` uses the
 `com.fasterxml.jackson` package; `3` uses the `tools.jackson` package. When empty, the codegen
-default (Jackson 2) is used. Currently only affects the Kotlin generator path.
+default (Jackson 2) is used. Currently only affects the builder deserialization annotations
+(`@JsonDeserialize` / `@JsonPOJOBuilder`) on Kotlin classes generated with
+[generateKotlinNullableClasses](#generatekotlinnullableclasses); listing both versions emits
+both sets of annotations.
 
 - Type: set<string> (allowed values: `2`, `3`)
 - Required: false

--- a/README.md
+++ b/README.md
@@ -641,6 +641,22 @@ classes are annotated with `@NullMarked` and nullable members with `@Nullable`.
 <generateJSpecifyAnnotations>true</generateJSpecifyAnnotations>
 ```
 
+### jacksonVersions
+
+Select which Jackson major version(s) the generated code targets. `2` uses the
+`com.fasterxml.jackson` package; `3` uses the `tools.jackson` package. When empty, the codegen
+default (Jackson 2) is used. Currently only affects the Kotlin generator path.
+
+- Type: set<string> (allowed values: `2`, `3`)
+- Required: false
+- Default: empty (Jackson 2)
+
+```xml
+<jacksonVersions>
+  <jacksonVersion>3</jacksonVersion>
+</jacksonVersions>
+```
+
 ### generateCustomAnnotations
 
 Generate custom annotations from `@annotate` directives in the schema. Used with

--- a/examples/graphqlcodegen-example/kotlin-jackson3/pom.xml
+++ b/examples/graphqlcodegen-example/kotlin-jackson3/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.github.deweyjose.graphqlcodegen-example</groupId>
+    <artifactId>graphqlcodegen-example-project</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>kotlin-jackson3</artifactId>
+  <packaging>jar</packaging>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <!--
+    Exercises the jacksonVersions parameter end to end: generates Kotlin classes
+    (generateKotlinNullableClasses) targeting Jackson 3 (tools.jackson), compiles them with the
+    Kotlin compiler, and deserializes JSON through the generated @JsonDeserialize builder with a
+    real Jackson 3 ObjectMapper.
+  -->
+
+  <properties>
+    <tools-jackson.version>3.2.1</tools-jackson.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${tools-jackson.version}</version>
+    </dependency>
+    <!--
+      Jackson 3 still uses the 2.x annotations artifact but needs a newer version than the
+      Spring Boot parent manages; pin the version jackson-bom ${tools-jackson.version} declares.
+    -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.22</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.github.deweyjose</groupId>
+        <artifactId>graphqlcodegen-maven-plugin</artifactId>
+        <configuration>
+          <packageName>io.github.deweyjose.graphqlcodegen.example.kotlin3</packageName>
+          <language>kotlin</language>
+          <generateKotlinNullableClasses>true</generateKotlinNullableClasses>
+          <jacksonVersions>
+            <jacksonVersion>3</jacksonVersion>
+          </jacksonVersions>
+          <!-- generated sources are Kotlin; the kotlin-maven-plugin compiles them instead -->
+          <autoAddSource>false</autoAddSource>
+          <writeToFiles>true</writeToFiles>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <configuration>
+          <jvmTarget>17</jvmTarget>
+        </configuration>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <sourceDirs>
+                <sourceDir>${project.build.directory}/generated-sources</sourceDir>
+              </sourceDirs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/examples/graphqlcodegen-example/kotlin-jackson3/src/main/resources/schema/main.graphqls
+++ b/examples/graphqlcodegen-example/kotlin-jackson3/src/main/resources/schema/main.graphqls
@@ -1,0 +1,8 @@
+type Query {
+    shows: [Show!]
+}
+
+type Show {
+    title: String!
+    releaseYear: Int
+}

--- a/examples/graphqlcodegen-example/kotlin-jackson3/src/test/java/io/github/deweyjose/graphqlcodegen/example/kotlin3/Jackson3DeserializationTest.java
+++ b/examples/graphqlcodegen-example/kotlin-jackson3/src/test/java/io/github/deweyjose/graphqlcodegen/example/kotlin3/Jackson3DeserializationTest.java
@@ -1,0 +1,31 @@
+package io.github.deweyjose.graphqlcodegen.example.kotlin3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.github.deweyjose.graphqlcodegen.example.kotlin3.types.Show;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+class Jackson3DeserializationTest {
+
+  private final JsonMapper mapper = JsonMapper.builder().build();
+
+  @Test
+  void deserializesGeneratedTypeThroughJackson3Builder() {
+    Show show =
+        mapper.readValue(
+            "{\"__typename\":\"Show\",\"title\":\"Ozark\",\"releaseYear\":2017}", Show.class);
+
+    assertEquals("Ozark", show.getTitle());
+    assertEquals(2017, show.getReleaseYear());
+  }
+
+  @Test
+  void absentFieldThrowsWhenAccessed() {
+    Show show = mapper.readValue("{\"title\":\"Ozark\"}", Show.class);
+
+    assertEquals("Ozark", show.getTitle());
+    assertThrows(IllegalStateException.class, show::getReleaseYear);
+  }
+}

--- a/examples/graphqlcodegen-example/pom.xml
+++ b/examples/graphqlcodegen-example/pom.xml
@@ -40,6 +40,7 @@
     <module>server</module>
     <module>client</module>
     <module>client-introspection</module>
+    <module>kotlin-jackson3</module>
   </modules>
 
   <dependencyManagement>

--- a/graphqlcodegen-maven-plugin/pom.xml
+++ b/graphqlcodegen-maven-plugin/pom.xml
@@ -38,7 +38,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
-    <graphql-dgs-codegen-core.version>8.5.0</graphql-dgs-codegen-core.version>
+    <graphql-dgs-codegen-core.version>8.6.0</graphql-dgs-codegen-core.version>
     <java.version>17</java.version>
     <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
     <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>

--- a/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/CodeGenConfigBuilder.java
+++ b/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/CodeGenConfigBuilder.java
@@ -1,9 +1,11 @@
 package io.github.deweyjose.graphqlcodegen;
 
 import com.netflix.graphql.dgs.codegen.CodeGenConfig;
+import com.netflix.graphql.dgs.codegen.JacksonVersion;
 import com.netflix.graphql.dgs.codegen.Language;
 import java.io.File;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -101,6 +103,8 @@ public class CodeGenConfigBuilder {
   private boolean trackInputFieldSet;
 
   private boolean generateJSpecifyAnnotations;
+
+  private Set<JacksonVersion> jacksonVersions = Collections.emptySet();
 
   public CodeGenConfigBuilder setSchemas(Set<String> schemas) {
     this.schemas = schemas;
@@ -331,6 +335,11 @@ public class CodeGenConfigBuilder {
     return this;
   }
 
+  public CodeGenConfigBuilder setJacksonVersions(Set<JacksonVersion> jacksonVersions) {
+    this.jacksonVersions = jacksonVersions == null ? Collections.emptySet() : jacksonVersions;
+    return this;
+  }
+
   public CodeGenConfig build() {
     return new CodeGenConfig(
         schemas,
@@ -375,6 +384,7 @@ public class CodeGenConfigBuilder {
         generatedAnnotationType,
         addDeprecatedAnnotation,
         trackInputFieldSet,
-        generateJSpecifyAnnotations);
+        generateJSpecifyAnnotations,
+        jacksonVersions);
   }
 }

--- a/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
+++ b/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java
@@ -171,6 +171,9 @@ public class Codegen extends AbstractMojo implements CodegenConfigProvider {
   @Parameter(property = "generateJSpecifyAnnotations", defaultValue = "false")
   private boolean generateJSpecifyAnnotations;
 
+  @Parameter(property = "jacksonVersions")
+  private Set<String> jacksonVersions;
+
   @Parameter(property = "generateCustomAnnotations", defaultValue = "false")
   private boolean generateCustomAnnotations;
 

--- a/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/CodegenConfigProvider.java
+++ b/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/CodegenConfigProvider.java
@@ -235,6 +235,13 @@ public interface CodegenConfigProvider {
   boolean isGenerateCustomAnnotations();
 
   /**
+   * @return the Jackson major versions to target in generated code ({@code "2"} for {@code
+   *     com.fasterxml.jackson}, {@code "3"} for {@code tools.jackson}). Empty means the codegen
+   *     default (Jackson 2). Only affects the Kotlin generator path.
+   */
+  Set<String> getJacksonVersions();
+
+  /**
    * @return included imports
    */
   Map<String, String> getIncludeImports();

--- a/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/CodegenExecutor.java
+++ b/graphqlcodegen-maven-plugin/src/main/java/io/github/deweyjose/graphqlcodegen/CodegenExecutor.java
@@ -2,6 +2,7 @@ package io.github.deweyjose.graphqlcodegen;
 
 import com.netflix.graphql.dgs.codegen.CodeGen;
 import com.netflix.graphql.dgs.codegen.CodeGenConfig;
+import com.netflix.graphql.dgs.codegen.JacksonVersion;
 import com.netflix.graphql.dgs.codegen.Language;
 import io.github.deweyjose.graphqlcodegen.parameters.ParameterMap;
 import io.github.deweyjose.graphqlcodegen.services.SchemaFileService;
@@ -9,6 +10,7 @@ import io.github.deweyjose.graphqlcodegen.services.TypeMappingService;
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -131,6 +133,7 @@ public class CodegenExecutor {
             .setAddDeprecatedAnnotation(request.isAddDeprecatedAnnotation())
             .setTrackInputFieldSet(request.isTrackInputFieldSet())
             .setGenerateJSpecifyAnnotations(request.isGenerateJSpecifyAnnotations())
+            .setJacksonVersions(toJacksonVersions(request.getJacksonVersions()))
             .build();
 
     if (request.isOmitNullInputFields()) {
@@ -160,5 +163,22 @@ public class CodegenExecutor {
             Collectors.toMap(
                 Map.Entry::getKey,
                 e -> e.getValue() == null ? Collections.emptyMap() : e.getValue().getProperties()));
+  }
+
+  /**
+   * Converts the plugin's string-valued jacksonVersions parameter ({@code "2"} / {@code "3"}) into
+   * the codegen's {@link JacksonVersion} set. A null or empty input yields an empty set, which the
+   * codegen treats as its default (Jackson 2).
+   *
+   * @param versions the configured Jackson major versions as strings
+   * @return the corresponding set of {@link JacksonVersion}
+   */
+  public static Set<JacksonVersion> toJacksonVersions(Set<String> versions) {
+    if (versions == null || versions.isEmpty()) {
+      return Collections.emptySet();
+    }
+    return versions.stream()
+        .map(JacksonVersion.Companion::fromString)
+        .collect(Collectors.toCollection(LinkedHashSet::new));
   }
 }

--- a/graphqlcodegen-maven-plugin/src/test/java/io/github/deweyjose/graphqlcodegen/CodegenExecutorTest.java
+++ b/graphqlcodegen-maven-plugin/src/test/java/io/github/deweyjose/graphqlcodegen/CodegenExecutorTest.java
@@ -182,6 +182,24 @@ class CodegenExecutorTest {
   }
 
   @Test
+  void testToJacksonVersionsNullEmptyAndNormal() {
+    assertEquals(Collections.emptySet(), CodegenExecutor.toJacksonVersions(null));
+    assertEquals(Collections.emptySet(), CodegenExecutor.toJacksonVersions(Collections.emptySet()));
+
+    assertEquals(
+        Set.of(com.netflix.graphql.dgs.codegen.JacksonVersion.JACKSON_2),
+        CodegenExecutor.toJacksonVersions(Set.of("2")));
+    assertEquals(
+        Set.of(
+            com.netflix.graphql.dgs.codegen.JacksonVersion.JACKSON_2,
+            com.netflix.graphql.dgs.codegen.JacksonVersion.JACKSON_3),
+        CodegenExecutor.toJacksonVersions(Set.of("2", "3")));
+
+    assertThrows(
+        IllegalArgumentException.class, () -> CodegenExecutor.toJacksonVersions(Set.of("bogus")));
+  }
+
+  @Test
   void testToMapNullAndEmptyAndNormal() {
     assertEquals(Collections.emptyMap(), CodegenExecutor.toMap(null));
     assertEquals(Collections.emptyMap(), CodegenExecutor.toMap(Collections.emptyMap()));

--- a/graphqlcodegen-maven-plugin/src/test/java/io/github/deweyjose/graphqlcodegen/CodegenExecutorTest.java
+++ b/graphqlcodegen-maven-plugin/src/test/java/io/github/deweyjose/graphqlcodegen/CodegenExecutorTest.java
@@ -181,6 +181,76 @@ class CodegenExecutorTest {
         "Projection methods with arguments should not use raw types");
   }
 
+  @SneakyThrows
+  @Test
+  void testGenerateKotlinDefaultsToJackson2() {
+    File generatedUserType = generateKotlinUserType(Collections.emptySet());
+
+    String content = Files.readString(generatedUserType.toPath());
+    assertTrue(
+        content.contains("com.fasterxml.jackson.databind"),
+        "Empty jacksonVersions should keep the pre-8.6.0 Jackson 2 databind annotations");
+    assertTrue(
+        content.contains("@JsonDeserialize(builder = User.Builder::class)"),
+        "Generated data class should use builder-based deserialization");
+    assertFalse(
+        content.contains("tools.jackson"),
+        "Empty jacksonVersions should not emit Jackson 3 annotations");
+  }
+
+  @SneakyThrows
+  @Test
+  void testGenerateKotlinWithJacksonVersion3() {
+    File generatedUserType = generateKotlinUserType(Set.of("3"));
+
+    String content = Files.readString(generatedUserType.toPath());
+    assertTrue(
+        content.contains("tools.jackson.databind"),
+        "jacksonVersions=3 should emit tools.jackson databind annotations");
+    assertFalse(
+        content.contains("com.fasterxml.jackson.databind"),
+        "jacksonVersions=3 should not emit Jackson 2 databind annotations");
+  }
+
+  @SneakyThrows
+  @Test
+  void testGenerateKotlinWithBothJacksonVersions() {
+    File generatedUserType = generateKotlinUserType(Set.of("2", "3"));
+
+    String content = Files.readString(generatedUserType.toPath());
+    assertTrue(
+        content.contains("com.fasterxml.jackson.databind"),
+        "jacksonVersions=2,3 should emit Jackson 2 databind annotations");
+    assertTrue(
+        content.contains("tools.jackson.databind"),
+        "jacksonVersions=2,3 should also emit Jackson 3 databind annotations");
+  }
+
+  @SneakyThrows
+  private File generateKotlinUserType(Set<String> jacksonVersions) {
+    File schemaFile = TestUtils.getFile("schema/test-schema-with-user.graphqls");
+
+    SchemaManifestService manifestService = new SchemaManifestService(outputDir, outputDir);
+    schemaFileService =
+        new SchemaFileService(
+            outputDir, manifestService, remoteSchemaService, schemaTransformationService);
+    executor = new CodegenExecutor(schemaFileService, typeMappingService, logger);
+
+    TestCodegenProvider config = new TestCodegenProvider();
+    config.setSchemaPaths(Set.of(schemaFile));
+    config.setOutputDir(outputDir);
+    config.setSchemaManifestOutputDir(outputDir);
+    config.setLanguage("kotlin");
+    config.setGenerateKotlinNullableClasses(true);
+    config.setJacksonVersions(jacksonVersions);
+
+    executor.execute(config, new HashSet<>(), new File("."));
+
+    File generatedUserType = new File(outputDir, "com/example/types/User.kt");
+    assertTrue(generatedUserType.exists(), "Should generate Kotlin User type file");
+    return generatedUserType;
+  }
+
   @Test
   void testToJacksonVersionsNullEmptyAndNormal() {
     assertEquals(Collections.emptySet(), CodegenExecutor.toJacksonVersions(null));

--- a/graphqlcodegen-maven-plugin/src/test/java/io/github/deweyjose/graphqlcodegen/TestCodegenProvider.java
+++ b/graphqlcodegen-maven-plugin/src/test/java/io/github/deweyjose/graphqlcodegen/TestCodegenProvider.java
@@ -104,6 +104,14 @@ public class TestCodegenProvider implements CodegenConfigProvider {
     this.jacksonVersions = jacksonVersions;
   }
 
+  public void setLanguage(String language) {
+    this.language = language;
+  }
+
+  public void setGenerateKotlinNullableClasses(boolean generateKotlinNullableClasses) {
+    this.generateKotlinNullableClasses = generateKotlinNullableClasses;
+  }
+
   // Add more setters as needed
 
   @Override

--- a/graphqlcodegen-maven-plugin/src/test/java/io/github/deweyjose/graphqlcodegen/TestCodegenProvider.java
+++ b/graphqlcodegen-maven-plugin/src/test/java/io/github/deweyjose/graphqlcodegen/TestCodegenProvider.java
@@ -56,6 +56,7 @@ public class TestCodegenProvider implements CodegenConfigProvider {
   private boolean trackInputFieldSet = false;
   private boolean generateJSpecifyAnnotations = false;
   private boolean generateCustomAnnotations = false;
+  private Set<String> jacksonVersions = new HashSet<>();
   private Map<String, String> includeImports = new HashMap<>();
   private Map<String, ParameterMap> includeEnumImports = new HashMap<>();
   private Map<String, ParameterMap> includeClassImports = new HashMap<>();
@@ -97,6 +98,10 @@ public class TestCodegenProvider implements CodegenConfigProvider {
 
   public void setGenerateJSpecifyAnnotations(boolean generateJSpecifyAnnotations) {
     this.generateJSpecifyAnnotations = generateJSpecifyAnnotations;
+  }
+
+  public void setJacksonVersions(Set<String> jacksonVersions) {
+    this.jacksonVersions = jacksonVersions;
   }
 
   // Add more setters as needed
@@ -324,6 +329,11 @@ public class TestCodegenProvider implements CodegenConfigProvider {
   @Override
   public boolean isGenerateCustomAnnotations() {
     return generateCustomAnnotations;
+  }
+
+  @Override
+  public Set<String> getJacksonVersions() {
+    return jacksonVersions;
   }
 
   @Override


### PR DESCRIPTION
Draft scaffolding for the weekly upgrade monitor. **Do not merge / do not mark ready** until a human applies `breaking-change-acknowledged` (or comments `/ack-breaking`).

Closes #337 once acknowledged and merged.

## What this does

- Bumps `graphql-dgs-codegen-core.version` `8.5.0` → `8.6.0`.
- Wires the single new CodeGenConfig option `jacksonVersions` through all layers.

## CodeGenConfig constructor delta (8.5.0 → 8.6.0)

One argument added at the **end** of the constructor; nothing removed/reordered/retyped:

```diff
   var generateJSpecifyAnnotations: Boolean = false,
+  var jacksonVersions: Set<JacksonVersion> = emptySet(),
 ) {
```

`jacksonVersions` selects the Jackson package for generated code (`2` → `com.fasterxml.jackson`, `3` → `tools.jackson`). Empty default reproduces pre-8.6.0 behaviour (Jackson 2); only the **Kotlin** generator path consumes it.

## Wiring (all layers done)

| Layer | Change |
|---|---|
| `Codegen.java` | `@Parameter(property = "jacksonVersions") Set<String> jacksonVersions` |
| `CodegenConfigProvider.java` | `Set<String> getJacksonVersions()` |
| `CodegenExecutor.java` | forward via new `toJacksonVersions(Set<String>)` helper (`String`→`JacksonVersion`) |
| `CodeGenConfigBuilder.java` | field + setter + trailing positional constructor arg |
| `TestCodegenProvider.java` / `CodegenExecutorTest` | getter wiring + `toJacksonVersions` unit test |
| `README.md` | `jacksonVersions` parameter docs |

## Build

`./mvnw -B -ntp -pl graphqlcodegen-maven-plugin spotless:apply` — clean.
`./mvnw -B -ntp -pl graphqlcodegen-maven-plugin verify` — **BUILD SUCCESS**, 55 tests, 0 failures, 0 errors, 2 skipped.

## Breaking-change assessment

Breaking **by policy** (compatibility-gate rule (e): any generation-path dependency bump). Actual risk is low — the only config change is an opt-in option with a behaviour-preserving empty default — but generated output *can* shift, so this needs human sign-off.

## Remaining manual work (checklist for the reviewer)

- [ ] Review the actual generated-output delta for the example harness (Java + Kotlin paths) with DGS 8.6.0.
- [ ] Confirm the chosen UX for `jacksonVersions` (`Set<String>` of `2`/`3`) vs. an enum-style parameter.
- [ ] Optionally add an end-to-end test asserting `jacksonVersions=3` emits `tools.jackson.*` imports on the Kotlin path (current coverage is the unit-level `toJacksonVersions` conversion only).
- [ ] Run the full reactor (`./mvnw -B -ntp install`) so the example modules build against the freshly-built plugin (this draft only ran `verify` on the plugin module).
- [ ] Apply `breaking-change-acknowledged` / `/ack-breaking`, then mark ready.
- [ ] Separately handle graphql-java 25.0 → 26.0 (untracked) and kotlinpoet 1.18.1 → 2.3.0 (dependabot #320) — both generation-path bumps, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015C1Vvc1S4y93GdVXVJnox4

---
_Generated by [Claude Code](https://claude.ai/code/session_015C1Vvc1S4y93GdVXVJnox4)_