### PR TITLE
Manage Jackson through jackson-bom so the versions cannot drift apart

### DIFF
--- a/graphqlcodegen-maven-plugin/pom.xml
+++ b/graphqlcodegen-maven-plugin/pom.xml
@@ -56,6 +56,7 @@
     <kotlinpoet-jvm.version>1.18.1</kotlinpoet-jvm.version>
     <spotless.version>3.10.1</spotless.version>
     <maven-core.version>3.9.12</maven-core.version>
+    <jackson-bom.version>2.22.2</jackson-bom.version>
   </properties>
 
   <dependencyManagement>
@@ -128,19 +129,11 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>2.22.1</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>2.22</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>2.22.0</version>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${jackson-bom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -215,6 +208,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Rebased onto `main` and reduced to what 3.10.1 does not cover.

The original scope of this PR, declaring `jackson-core` and `jackson-annotations` so they
survive `flattenMode=ossrh`, shipped in #355 / 3.10.1, so that part is dropped here. I
verified 3.10.1 against a real consumer (details in #353).

## What is left

**1. The three pins can still drift apart.** That drift is what broke 3.10.0: dependabot
moved `jackson-databind` to 2.22.0 while `jackson-annotations` stayed at the version
`graphql-dgs-codegen-core` contributes. Declaring the artifacts fixes the symptom for the
current versions; it does not stop the next one-sided bump from landing the same
incompatible pair, this time in the published pom rather than around it. Importing
`jackson-bom` makes the set consistent by construction and leaves one version for
dependabot to bump instead of three.

**2. `jackson-annotations` is `runtime`, not `compile`.** Nothing in this module compiles
against it: `RemoteSchemaService` imports only `com.fasterxml.jackson.core.type.TypeReference`
and `com.fasterxml.jackson.databind.ObjectMapper`. It is needed only when databind's
`JacksonAnnotationIntrospector` initializes, which is exactly what the scope says.

These are independent concerns, so drop the `runtime` line if you would rather keep the
diff to the bom alone.

Effective versions for consumers:

| | 3.10.1 | with this PR |
|---|---|---|
| `jackson-core` | 2.22.1 | 2.22.2 |
| `jackson-databind` | 2.22.0 | 2.22.2 |
| `jackson-annotations` | 2.22 | 2.22 (unchanged) |

`jackson-annotations` staying at `2.22` is correct, not a leftover: `jackson-bom` has
carried annotations without a patch level since 2.20
(`<jackson.version.annotations>2.22</jackson.version.annotations>`), and a `2.22.0`
artifact does not exist.

## Verification

- `dependency:tree` before and after: exactly the same three Jackson artifacts, with
  nothing else pulled in or managed by the bom. After the change they resolve to
  `jackson-databind:2.22.2:compile`, `jackson-annotations:2.22:runtime`,
  `jackson-core:2.22.2:compile`.
- The flattened pom (`target/flattened-pom/.flattened-pom.xml`) carries all three at depth 1
  with those versions, and `runtime` survives the flattening.
- `verify -pl graphqlcodegen-maven-plugin`: 68 tests, 0 failures, 2 skipped; enforcer
  `ban-spring-boot` green.

One environment note: `spotless:check` and the manifest checksum tests fail on a Windows
checkout with CRLF line endings (verified identical on an unmodified tree), so I ran with
`-Dspotless.check.skip=true` and did not run `spotless:apply`, which would have rewritten
every Java file to CRLF. The diff is pom-only and the spotless config covers `<java>` only.
