### PR TITLE
Fix Jackson annotations classpath mismatch (#353)

### DIFF
--- a/examples/graphqlcodegen-example/pom.xml
+++ b/examples/graphqlcodegen-example/pom.xml
@@ -26,7 +26,7 @@
       external network dependency and stays consistent with the tested commit.
     -->
     <codegen.server.schemaUrl>https://raw.githubusercontent.com/deweyjose/graphqlcodegen-example/refs/heads/main/server/src/main/resources/schema/main.graphqls</codegen.server.schemaUrl>
-    <graphql-codegen-plugin.version>3.10.0</graphql-codegen-plugin.version>
+    <graphql-codegen-plugin.version>3.10.1</graphql-codegen-plugin.version>
     <dgs.framework.version>12.0.1</dgs.framework.version>
     <!--
       The Spring Boot parent's dependencyManagement wins over the imported DGS platform BOM,

--- a/graphqlcodegen-maven-plugin/AGENTS.md
+++ b/graphqlcodegen-maven-plugin/AGENTS.md
@@ -80,6 +80,11 @@ all layers or it is silently unreachable from Maven:
   of `graphql-dgs-codegen-core` and is intentionally allowed.
 - Prefer **name-based test assertions** over hardcoded counts (assert a fixture name is
   present, not that there are exactly N fixtures).
+- **Flattened POM drops `dependencyManagement`.** Release uses `flatten-maven-plugin`
+  `flattenMode=ossrh`, which strips `dependencyManagement` from the published POM.
+  Version pins that only live there do not reach consumers. Keep `jackson-annotations`
+  and `jackson-core` as **direct** `<dependencies>` so they survive flattening and win
+  mediation over `graphql-dgs-codegen-core`'s older Jackson (issue #353).
 
 ## Build & test (from the repo root)
 

--- a/graphqlcodegen-maven-plugin/pom.xml
+++ b/graphqlcodegen-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
   <groupId>io.github.deweyjose</groupId>
   <artifactId>graphqlcodegen-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>3.10.0</version>
+  <version>3.10.1</version>
 
   <name>GraphQL Code Generator Maven Plugin</name>
   <description>Maven plugin for GraphQL code generation</description>

--- a/graphqlcodegen-maven-plugin/pom.xml
+++ b/graphqlcodegen-maven-plugin/pom.xml
@@ -201,9 +201,24 @@
       <groupId>com.graphql-java</groupId>
       <artifactId>graphql-java</artifactId>
     </dependency>
+    <!--
+      jackson-annotations and jackson-core MUST be direct dependencies. flattenMode=ossrh
+      strips dependencyManagement from the published POM, so Maven mediation otherwise
+      picks graphql-dgs-codegen-core's jackson-annotations:2.18.3 over jackson-databind
+      2.22's requirement. JsonSerializeAs was added in annotations 2.21; without this
+      pin, RemoteSchemaService's ObjectMapper fails with NoClassDefFoundError (#353).
+    -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/graphqlcodegen-maven-plugin/src/test/java/io/github/deweyjose/graphqlcodegen/FlattenedPomJacksonDependenciesTest.java
+++ b/graphqlcodegen-maven-plugin/src/test/java/io/github/deweyjose/graphqlcodegen/FlattenedPomJacksonDependenciesTest.java
@@ -1,0 +1,152 @@
+package io.github.deweyjose.graphqlcodegen;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+/**
+ * Guards issue #353: jackson-databind 2.22+ references {@code JsonSerializeAs} (added in
+ * jackson-annotations 2.21). The published POM is flattened with {@code flattenMode=ossrh}, which
+ * strips {@code dependencyManagement}, so Jackson must be declared as direct dependencies or Maven
+ * mediation of {@code graphql-dgs-codegen-core}'s older jackson-annotations wins.
+ */
+class FlattenedPomJacksonDependenciesTest {
+
+  private static final String JACKSON_GROUP = "com.fasterxml.jackson.core";
+  private static final String[] REQUIRED_ARTIFACTS = {
+    "jackson-databind", "jackson-annotations", "jackson-core"
+  };
+
+  @Test
+  void sourcePomDeclaresJacksonArtifactsAsDirectDependencies() throws Exception {
+    File pom = new File("pom.xml");
+    assertTrue(pom.isFile(), "Expected plugin pom.xml at " + pom.getAbsolutePath());
+
+    Map<String, String> direct = directJacksonDependencies(parse(pom));
+    for (String artifact : REQUIRED_ARTIFACTS) {
+      assertTrue(
+          direct.containsKey(artifact),
+          artifact
+              + " must be a direct <dependency> so it survives flattenMode=ossrh"
+              + " (found: "
+              + direct.keySet()
+              + ")");
+    }
+  }
+
+  @Test
+  void jsonSerializeAsIsLoadable() {
+    // Canary that the reactor classpath itself has annotations >= 2.21.
+    assertNotNull(com.fasterxml.jackson.annotation.JsonSerializeAs.class);
+  }
+
+  @Test
+  void flattenedPomKeepsJacksonDirectDependenciesWithVersions() throws Exception {
+    File flattened = new File("target/flattened-pom/.flattened-pom.xml");
+    assumeTrue(
+        flattened.isFile(),
+        "Flattened POM is produced in process-resources; skip when tests run without Maven");
+
+    Document doc = parse(flattened);
+    assertFalse(
+        hasDependencyManagement(doc),
+        "ossrh flatten mode should strip dependencyManagement; if it is present the published"
+            + " POM may hide Jackson mediation bugs again");
+
+    Map<String, String> direct = directJacksonDependencies(doc);
+    for (String artifact : REQUIRED_ARTIFACTS) {
+      String version = direct.get(artifact);
+      assertTrue(
+          version != null && !version.isBlank(),
+          artifact
+              + " must appear in the flattened POM with an interpolated version"
+              + " (found: "
+              + direct
+              + ")");
+    }
+
+    String annotationsVersion = direct.get("jackson-annotations");
+    assertTrue(
+        isAtLeast(annotationsVersion, 2, 21),
+        "jackson-annotations must be >= 2.21 for JsonSerializeAs, was " + annotationsVersion);
+  }
+
+  private static Document parse(File pom) throws Exception {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(true);
+    return factory.newDocumentBuilder().parse(pom);
+  }
+
+  private static Map<String, String> directJacksonDependencies(Document doc) throws Exception {
+    XPath xpath = XPathFactory.newInstance().newXPath();
+    NodeList nodes =
+        (NodeList)
+            xpath.evaluate(
+                "/*[local-name()='project']/*[local-name()='dependencies']"
+                    + "/*[local-name()='dependency']",
+                doc,
+                XPathConstants.NODESET);
+    Map<String, String> jackson = new LinkedHashMap<>();
+    for (int i = 0; i < nodes.getLength(); i++) {
+      Element dep = (Element) nodes.item(i);
+      if (!JACKSON_GROUP.equals(childText(dep, "groupId"))) {
+        continue;
+      }
+      jackson.put(childText(dep, "artifactId"), childText(dep, "version"));
+    }
+    return jackson;
+  }
+
+  private static boolean hasDependencyManagement(Document doc) throws Exception {
+    XPath xpath = XPathFactory.newInstance().newXPath();
+    NodeList nodes =
+        (NodeList)
+            xpath.evaluate(
+                "/*[local-name()='project']/*[local-name()='dependencyManagement']",
+                doc,
+                XPathConstants.NODESET);
+    return nodes.getLength() > 0;
+  }
+
+  private static String childText(Element parent, String localName) {
+    NodeList children = parent.getElementsByTagNameNS("*", localName);
+    if (children.getLength() == 0) {
+      children = parent.getElementsByTagName(localName);
+    }
+    if (children.getLength() == 0) {
+      return "";
+    }
+    return children.item(0).getTextContent().trim();
+  }
+
+  private static boolean isAtLeast(String version, int major, int minor) {
+    if (version == null || version.isBlank()) {
+      return false;
+    }
+    String[] parts = version.split("[.-]");
+    int vMajor = parts.length > 0 ? parseIntOrZero(parts[0]) : 0;
+    int vMinor = parts.length > 1 ? parseIntOrZero(parts[1]) : 0;
+    return vMajor > major || (vMajor == major && vMinor >= minor);
+  }
+
+  private static int parseIntOrZero(String part) {
+    try {
+      return Integer.parseInt(part);
+    } catch (NumberFormatException e) {
+      return 0;
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.github.deweyjose</groupId>
   <artifactId>graphqlcodegen-parent</artifactId>
-  <version>3.10.0</version>
+  <version>3.10.1</version>
   <packaging>pom</packaging>
 
   <name>GraphQL Code Generator (build reactor)</name>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #353.

**Problem.** Plugin 3.10.0 ships `jackson-databind:2.22.0` as a direct dependency, but `jackson-annotations` is only pinned in `dependencyManagement`. `flattenMode=ossrh` strips that section from the published POM, so Maven mediation then picks `jackson-annotations:2.18.3` from `graphql-dgs-codegen-core`. Databind 2.22 references `JsonSerializeAs` (added in annotations 2.21), and `RemoteSchemaService`'s `ObjectMapper` fails with `NoClassDefFoundError`.

**Fix.** Declare `jackson-annotations` and `jackson-core` as direct dependencies so they survive flattening and win mediation. A unit test asserts they are present in the source POM and, after flatten, in the published POM with an annotations version `>= 2.21`.

**Release.** Version bumped to **3.10.1** in the plugin POM, root aggregator, and the example's `graphql-codegen-plugin.version` property.

No generated-code or user-facing option changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07be4-52e4-7043-bdef-6866198363a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07be4-52e4-7043-bdef-6866198363a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

